### PR TITLE
chore: bump version to 0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "node-telegram-bot-api": "^0.66.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps version to 0.2.9 following the /restart command addition (merged in #3).