### PR TITLE
fix: prevent duplicate processes on /restart under launchd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "node-telegram-bot-api": "^0.66.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -719,12 +719,18 @@ export class CcTgBot {
     await this.bot.sendMessage(chatId, "Restarting bot... brb.");
     await new Promise(resolve => setTimeout(resolve, 1000));
     this.stop();
-    const child = spawn(process.execPath, process.argv.slice(1), {
-      detached: true,
-      stdio: "inherit",
-      env: process.env,
-    });
-    child.unref();
+
+    const isLaunchd = process.ppid === 1;
+    if (!isLaunchd) {
+      // Running manually — spawn a replacement process
+      const child = spawn(process.execPath, process.argv.slice(1), {
+        detached: true,
+        stdio: "ignore",
+        env: process.env,
+      });
+      child.unref();
+    }
+    // If launchd-managed, just exit — launchd will restart us
     process.exit(0);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,32 @@
  *   CWD                  — working directory for Claude Code (default: process.cwd())
  */
 
+import { existsSync, writeFileSync, unlinkSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { CcTgBot } from "./bot.js";
+
+const LOCK_FILE = join(tmpdir(), "cc-tg.lock");
+
+function acquireLock(): boolean {
+  if (existsSync(LOCK_FILE)) {
+    try {
+      const pid = parseInt(readFileSync(LOCK_FILE, "utf8").trim());
+      process.kill(pid, 0);
+      console.error(`[cc-tg] Another instance is already running (PID ${pid}). Exiting.`);
+      return false;
+    } catch {
+      // PID is dead — stale lock, take over
+    }
+  }
+  writeFileSync(LOCK_FILE, String(process.pid));
+  process.on("exit", () => { try { unlinkSync(LOCK_FILE); } catch {} });
+  return true;
+}
+
+if (!acquireLock()) {
+  process.exit(1);
+}
 
 function required(name: string): string {
   const val = process.env[name];


### PR DESCRIPTION
## Summary
- Detect launchd (`ppid === 1`) in `handleRestart` and skip spawning a child process — launchd handles restart on exit via `KeepAlive=true`
- Fix `stdio: "inherit"` → `"ignore"` for the non-launchd spawn path to avoid file descriptor leaks
- Add single-instance lock file (`/tmp/cc-tg.lock`) at startup: checks if a prior PID is still alive, exits if so, clears stale locks otherwise

## Test plan
- [ ] Run under launchd: `/restart` should produce exactly one new process (not two)
- [ ] Run manually in terminal: `/restart` should still spawn a replacement process and exit
- [ ] Rapid `/restart` calls: second instance should detect lock and exit immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)