### PR TITLE
feat: cc-agent cost in /cost + scheduler roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,17 @@
+## cc-agent: Self-Driving Scheduler Roadmap
+
+### Phase 1: Dependent job scheduling
+- `depends_on: string[]` field on SpawnOptions
+- Jobs with unmet dependencies stay in `pending` status
+- Internal scheduler loop (setInterval, 5s) checks pending jobs, promotes to running when dependencies are done
+- If dependency failed → dependent job fails with reason
+
+### Phase 2: create_plan tool
+- `create_plan({ goal, steps: [{id, task, repo, depends_on}] })`
+- Returns plan_id
+- Steps execute in dependency order via Phase 1 scheduler
+- `list_plans` / `get_plan` tools
+
+### Phase 3: Cron-aware job completion
+- Cron prompt template supports `{{list_jobs}}` placeholder — injected at runtime
+- Cron sessions can react to job completions without hardcoding logic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -7,7 +7,7 @@ import TelegramBot from "node-telegram-bot-api";
 import { existsSync, createWriteStream, mkdirSync, statSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { resolve, basename, join } from "path";
 import os from "os";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import https from "https";
 import http from "http";
 import { ClaudeProcess, extractText, ClaudeMessage, UsageEvent } from "./claude.js";
@@ -99,6 +99,28 @@ function formatCostReport(cost: SessionCost): string {
 function formatCronCostFooter(usage: UsageEvent): string {
   const cost = computeCostUsd(usage);
   return `\n💰 Cron cost: $${cost.toFixed(4)} (${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out tokens)`;
+}
+
+function formatAgentCostSummary(text: string): string {
+  try {
+    const data = JSON.parse(text) as Record<string, unknown>;
+    const totalCost = ((data.total_cost_usd ?? data.total_cost ?? 0) as number);
+    const totalJobs = ((data.total_jobs ?? data.job_count ?? 0) as number);
+    const byRepo = (data.by_repo ?? []) as Array<Record<string, unknown>>;
+    const lines = [
+      "🤖 Agent jobs (all time)",
+      `Total: $${totalCost.toFixed(2)} across ${totalJobs} jobs`,
+    ];
+    for (const entry of byRepo) {
+      const repo = (entry.repo ?? entry.repository ?? "unknown") as string;
+      const cost = ((entry.cost_usd ?? entry.cost ?? 0) as number);
+      const jobs = ((entry.job_count ?? entry.jobs ?? 0) as number);
+      lines.push(`  ${repo}: $${cost.toFixed(2)} (${jobs} jobs)`);
+    }
+    return lines.join("\n");
+  } catch {
+    return `🤖 Agent jobs (all time)\n${text}`;
+  }
 }
 
 class CostStore {
@@ -299,7 +321,16 @@ export class CcTgBot {
     // /cost — show session token usage and cost
     if (text === "/cost") {
       const cost = this.costStore.get(chatId);
-      await this.bot.sendMessage(chatId, formatCostReport(cost));
+      let reply = formatCostReport(cost);
+      try {
+        const rawSummary = await this.callCcAgentTool("cost_summary");
+        if (rawSummary) {
+          reply += "\n\n" + formatAgentCostSummary(rawSummary);
+        }
+      } catch (err) {
+        console.error("[cost] cc-agent cost_summary failed:", (err as Error).message);
+      }
+      await this.bot.sendMessage(chatId, reply);
       return;
     }
 
@@ -1022,6 +1053,78 @@ export class CcTgBot {
     }
 
     await this.bot.sendDocument(chatId, filePath);
+  }
+
+  private callCcAgentTool(toolName: string, args: Record<string, unknown> = {}): Promise<string | null> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const done = (val: string | null) => {
+        if (!settled) { settled = true; resolve(val); }
+      };
+
+      let proc: ReturnType<typeof spawn>;
+      try {
+        proc = spawn("npx", ["-y", "@gonzih/cc-agent@latest"], {
+          env: { ...process.env },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (err) {
+        console.error("[mcp] failed to spawn cc-agent:", (err as Error).message);
+        done(null);
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        console.warn("[mcp] cc-agent tool call timed out");
+        proc.kill();
+        done(null);
+      }, 30_000);
+
+      let buffer = "";
+      const sendMsg = (msg: unknown) => { proc.stdin!.write(JSON.stringify(msg) + "\n"); };
+
+      sendMsg({
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "cc-tg", version: "1.0.0" } },
+      });
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        buffer += chunk.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line) as Record<string, unknown>;
+            if (msg.id === 1 && "result" in msg) {
+              sendMsg({ jsonrpc: "2.0", method: "notifications/initialized" });
+              sendMsg({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: toolName, arguments: args } });
+            } else if (msg.id === 2) {
+              clearTimeout(timeout);
+              if (msg.error) {
+                console.error("[mcp] cost_summary error:", JSON.stringify(msg.error));
+                proc.kill();
+                done(null);
+                return;
+              }
+              const result = msg.result as Record<string, unknown> | undefined;
+              const content = result?.content as Array<Record<string, unknown>> | undefined;
+              const text = (content ?? []).filter((b) => b.type === "text").map((b) => b.text as string).join("");
+              proc.kill();
+              done(text || null);
+            }
+          } catch { /* ignore non-JSON lines */ }
+        }
+      });
+
+      proc.on("error", (err) => {
+        console.error("[mcp] cc-agent spawn error:", err.message);
+        clearTimeout(timeout);
+        done(null);
+      });
+
+      proc.on("exit", () => { clearTimeout(timeout); done(null); });
+    });
   }
 
   private killSession(chatId: number, keepCrons = true): void {


### PR DESCRIPTION
## Summary
- `/cost` command now calls cc-agent MCP `cost_summary` tool directly via JSON-RPC stdio and appends a `🤖 Agent jobs (all time)` section with total cost, job count, and per-repo breakdown
- Section is silently skipped if `cost_summary` fails or returns no data
- Added `ROADMAP.md` with cc-agent dependent job scheduling plan (Phases 1–3: depends_on scheduling, create_plan tool, cron-aware job completion)
- Bumped version to 0.2.19

## Test plan
- [ ] `/cost` shows session cost section as before
- [ ] `/cost` shows agent jobs section when cc-agent is running and has job history
- [ ] `/cost` works gracefully when cc-agent is unavailable (no error, section omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)