### PR TITLE
fix: restore message delivery broken by cost tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "license": "MIT",
       "dependencies": {
         "node-telegram-bot-api": "^0.66.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -545,7 +545,11 @@ export class CcTgBot {
     }
 
     // Hybrid file upload: find files mentioned in result text that Claude actually wrote
-    this.uploadMentionedFiles(chatId, text, session);
+    try {
+      this.uploadMentionedFiles(chatId, text, session);
+    } catch (err) {
+      console.error(`[tg:${chatId}] uploadMentionedFiles error:`, (err as Error).message);
+    }
   }
 
   private trackWrittenFiles(msg: ClaudeMessage, session: Session, cwd?: string): void {
@@ -694,7 +698,12 @@ export class CcTgBot {
         console.log(`[claude:files] skipping sensitive file: ${filePath}`);
         continue;
       }
-      const fileSize = statSync(filePath).size;
+      let fileSize: number;
+      try {
+        fileSize = statSync(filePath).size;
+      } catch {
+        continue; // file disappeared between existsSync and statSync
+      }
       const MAX_TG_FILE_BYTES = 50 * 1024 * 1024;
       if (fileSize > MAX_TG_FILE_BYTES) {
         const mb = (fileSize / (1024 * 1024)).toFixed(1);
@@ -753,7 +762,12 @@ export class CcTgBot {
 
         const result = output.trim();
         if (result) {
-          const footer = formatCronCostFooter(cronUsage);
+          let footer = "";
+          try {
+            footer = formatCronCostFooter(cronUsage);
+          } catch (err) {
+            console.error(`[cron] cost footer error:`, (err as Error).message);
+          }
           const chunks = splitMessage(`🕐 ${result}${footer}`);
           (async () => {
             for (const chunk of chunks) {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -153,37 +153,40 @@ export class ClaudeProcess extends EventEmitter {
 
     for (const line of lines) {
       if (!line.trim()) continue;
+
+      let raw: Record<string, unknown>;
       try {
-        const raw = JSON.parse(line) as Record<string, unknown>;
-
-        // Emit usage events from Anthropic API stream events passed through by Claude CLI
-        if (raw.type === "message_start") {
-          const usage = ((raw.message as Record<string, unknown> | undefined)?.usage) as Record<string, number> | undefined;
-          if (usage) {
-            this.emit("usage", {
-              inputTokens: usage.input_tokens ?? 0,
-              outputTokens: 0, // output_tokens at message_start is always 0
-              cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-              cacheWriteTokens: usage.cache_creation_input_tokens ?? 0,
-            } satisfies UsageEvent);
-          }
-        } else if (raw.type === "message_delta") {
-          const usage = raw.usage as Record<string, number> | undefined;
-          if (usage?.output_tokens) {
-            this.emit("usage", {
-              inputTokens: 0,
-              outputTokens: usage.output_tokens,
-              cacheReadTokens: 0,
-              cacheWriteTokens: 0,
-            } satisfies UsageEvent);
-          }
-        }
-
-        const msg = this.parseMessage(raw);
-        if (msg) this.emit("message", msg);
+        raw = JSON.parse(line) as Record<string, unknown>;
       } catch {
         // Non-JSON line (startup noise etc.) — ignore
+        continue;
       }
+
+      // Emit usage events from Anthropic API stream events passed through by Claude CLI
+      if (raw.type === "message_start") {
+        const usage = ((raw.message as Record<string, unknown> | undefined)?.usage) as Record<string, number> | undefined;
+        if (usage) {
+          this.emit("usage", {
+            inputTokens: usage.input_tokens ?? 0,
+            outputTokens: 0, // output_tokens at message_start is always 0
+            cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+            cacheWriteTokens: usage.cache_creation_input_tokens ?? 0,
+          } satisfies UsageEvent);
+        }
+      } else if (raw.type === "message_delta") {
+        const usage = raw.usage as Record<string, number> | undefined;
+        if (usage?.output_tokens) {
+          this.emit("usage", {
+            inputTokens: 0,
+            outputTokens: usage.output_tokens,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          } satisfies UsageEvent);
+        }
+      }
+
+      const msg = this.parseMessage(raw);
+      if (msg) this.emit("message", msg);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `drainBuffer()` in `claude.ts` wrapped `this.emit("message", msg)` inside the JSON-parse `try/catch`. Any exception thrown by a message listener — including errors from the new cost-tracking code — was silently swallowed as if it were a non-JSON line. This is why `[cron] task complete` appeared in logs but no message reached Telegram.
- **Cron guard**: Added `try/catch` around `formatCronCostFooter()` in the cron result handler so a cost calculation error can never prevent the Telegram send.
- **File upload guard**: Wrapped `statSync()` in `uploadMentionedFiles` against a TOCTOU race (file deleted between `existsSync` and `statSync`), and wrapped the whole call in `flushPending` so any unexpected throw there can never block message delivery.
- Bumped to 0.2.21.

## Test plan

- [ ] Cron task fires → result message arrives in Telegram (with cost footer)
- [ ] Regular Claude response arrives in Telegram after each prompt
- [ ] `/cost` command still works and shows session cost + agent summary
- [ ] If cost tracking throws internally, messages still deliver (error logged, not swallowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)