### PR TITLE
feat: usage-limit graceful sleep for Telegram

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -13,6 +13,7 @@ import http from "http";
 import { ClaudeProcess, extractText, ClaudeMessage, UsageEvent } from "./claude.js";
 import { transcribeVoice, isVoiceAvailable } from "./voice.js";
 import { CronManager } from "./cron.js";
+import { detectUsageLimit } from "./usage-limit.js";
 
 const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "start", description: "Reset session and start fresh" },
@@ -45,6 +46,16 @@ interface Session {
   lastMessageId?: number;
   /** Files written by Claude tools during this turn — cleared after each result */
   writtenFiles: Set<string>;
+  /** The last prompt sent to this session — used for usage-limit retries */
+  currentPrompt: string;
+  /** When true, prepend "✅ Claude is back!" to the next flushed response */
+  isRetry: boolean;
+}
+
+interface PendingRetry {
+  text: string;
+  attempt: number;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 const FLUSH_DELAY_MS = 800; // debounce streaming chunks into one Telegram message
@@ -189,6 +200,7 @@ class CostStore {
 export class CcTgBot {
   private bot: TelegramBot;
   private sessions = new Map<number, Session>();
+  private pendingRetries = new Map<number, PendingRetry>();
   private opts: BotOptions;
   private cron: CronManager;
   private costStore: CostStore;
@@ -279,7 +291,10 @@ export class CcTgBot {
     // /status
     if (text === "/status") {
       const has = this.sessions.has(chatId);
-      await this.bot.sendMessage(chatId, has ? "Session active." : "No active session.");
+      let status = has ? "Session active." : "No active session.";
+      const sleeping = this.pendingRetries.size;
+      if (sleeping > 0) status += `\n⏸ ${sleeping} request(s) sleeping (usage limit).`;
+      await this.bot.sendMessage(chatId, status);
       return;
     }
 
@@ -343,7 +358,9 @@ export class CcTgBot {
 
     const session = this.getOrCreateSession(chatId);
     try {
-      session.claude.sendPrompt(buildPromptWithReplyContext(text, msg));
+      const prompt = buildPromptWithReplyContext(text, msg);
+      session.currentPrompt = prompt;
+      session.claude.sendPrompt(prompt);
       this.startTyping(chatId, session);
     } catch (err) {
       await this.bot.sendMessage(chatId, `Error sending to Claude: ${(err as Error).message}`);
@@ -371,7 +388,9 @@ export class CcTgBot {
       // Feed transcript into Claude as if user typed it
       const session = this.getOrCreateSession(chatId);
       try {
-        session.claude.sendPrompt(buildPromptWithReplyContext(transcript, msg));
+        const prompt = buildPromptWithReplyContext(transcript, msg);
+        session.currentPrompt = prompt;
+        session.claude.sendPrompt(prompt);
         this.startTyping(chatId, session);
       } catch (err) {
         await this.bot.sendMessage(chatId, `Error sending to Claude: ${(err as Error).message}`);
@@ -451,6 +470,8 @@ export class CcTgBot {
       flushTimer: null,
       typingTimer: null,
       writtenFiles: new Set(),
+      currentPrompt: "",
+      isRetry: false,
     };
 
     claude.on("usage", (usage: UsageEvent) => {
@@ -502,6 +523,42 @@ export class CcTgBot {
     const text = extractText(msg);
     if (!text) return;
 
+    // Check for usage/rate limit signals before forwarding to Telegram
+    const sig = detectUsageLimit(text);
+    if (sig.detected) {
+      const lastPrompt = session.currentPrompt;
+      const prevRetry = this.pendingRetries.get(chatId);
+      const attempt = (prevRetry?.attempt ?? 0) + 1;
+
+      if (prevRetry) clearTimeout(prevRetry.timer);
+
+      this.bot.sendMessage(chatId, sig.humanMessage).catch(() => {});
+      this.killSession(chatId);
+
+      if (attempt > 3) {
+        this.bot.sendMessage(chatId, "❌ Claude usage limit persists after 3 retries. Please try again later.").catch(() => {});
+        this.pendingRetries.delete(chatId);
+        return;
+      }
+
+      console.log(`[usage-limit:${chatId}] ${sig.reason} — scheduling retry attempt=${attempt} in ${sig.retryAfterMs}ms`);
+      const timer = setTimeout(() => {
+        this.pendingRetries.delete(chatId);
+        try {
+          const retrySession = this.getOrCreateSession(chatId);
+          retrySession.currentPrompt = lastPrompt;
+          retrySession.isRetry = true;
+          retrySession.claude.sendPrompt(lastPrompt);
+          this.startTyping(chatId, retrySession);
+        } catch (err) {
+          this.bot.sendMessage(chatId, `❌ Failed to retry: ${(err as Error).message}`).catch(() => {});
+        }
+      }, sig.retryAfterMs);
+
+      this.pendingRetries.set(chatId, { text: lastPrompt, attempt, timer });
+      return;
+    }
+
     // Accumulate text and debounce — Claude streams chunks rapidly
     session.pendingText += text;
 
@@ -531,7 +588,8 @@ export class CcTgBot {
     session.flushTimer = null;
     if (!raw) return;
 
-    const text = raw;
+    const text = session.isRetry ? `✅ Claude is back!\n\n${raw}` : raw;
+    session.isRetry = false;
 
     // Telegram max message length is 4096 chars — split if needed
     const chunks = splitMessage(text);

--- a/src/usage-limit.test.ts
+++ b/src/usage-limit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { detectUsageLimit } from "./usage-limit.js";
+
+describe("detectUsageLimit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Fix "now" to a known time: 2026-03-22T10:30:00Z
+    vi.setSystemTime(new Date("2026-03-22T10:30:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns not-detected for normal text", () => {
+    const sig = detectUsageLimit("Here is a response about your code.");
+    expect(sig.detected).toBe(false);
+    expect(sig.retryAfterMs).toBe(0);
+    expect(sig.humanMessage).toBe("");
+  });
+
+  it("detects 'usage limit' phrase", () => {
+    const sig = detectUsageLimit("You have reached your usage limit for this period.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+    expect(sig.retryAfterMs).toBeGreaterThan(0);
+    expect(sig.humanMessage).toContain("⏸ Claude usage limit reached");
+    expect(sig.humanMessage).toContain("auto-resume");
+  });
+
+  it("detects 'extra usage' phrase", () => {
+    const sig = detectUsageLimit("You need extra usage to continue.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+  });
+
+  it("detects 'usage has been disabled' phrase", () => {
+    const sig = detectUsageLimit("Your usage has been disabled.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+  });
+
+  it("detects 'billing_error' phrase", () => {
+    const sig = detectUsageLimit("Error: billing_error encountered.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+  });
+
+  it("is case-insensitive for usage limit", () => {
+    const sig = detectUsageLimit("USAGE LIMIT exceeded.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+  });
+
+  it("detects 'rate limit'", () => {
+    const sig = detectUsageLimit("Error: rate limit exceeded.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("rate_limit");
+    expect(sig.retryAfterMs).toBe(2 * 60 * 1000);
+    expect(sig.humanMessage).toContain("⏸ Rate limited");
+    expect(sig.humanMessage).toContain("2 minutes");
+  });
+
+  it("detects 'overloaded'", () => {
+    const sig = detectUsageLimit("The service is overloaded, please try again.");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("rate_limit");
+    expect(sig.retryAfterMs).toBe(2 * 60 * 1000);
+  });
+
+  it("usage_exhausted retryAfterMs targets next hour boundary + 5 min", () => {
+    // Now is 10:30, next hour boundary is 11:00 + 5min = 11:05
+    const sig = detectUsageLimit("usage limit reached");
+    const expectedMs = new Date("2026-03-22T11:05:00Z").getTime() - new Date("2026-03-22T10:30:00Z").getTime();
+    expect(sig.retryAfterMs).toBe(expectedMs);
+  });
+
+  it("humanMessage includes the wake time UTC string", () => {
+    const sig = detectUsageLimit("usage limit reached");
+    const wakeDate = new Date("2026-03-22T11:05:00Z");
+    expect(sig.humanMessage).toContain(wakeDate.toUTCString());
+  });
+});

--- a/src/usage-limit.ts
+++ b/src/usage-limit.ts
@@ -1,0 +1,39 @@
+export interface UsageLimitSignal {
+  detected: boolean;
+  reason: 'usage_exhausted' | 'rate_limit';
+  retryAfterMs: number;
+  humanMessage: string;
+}
+
+export function detectUsageLimit(text: string): UsageLimitSignal {
+  const lower = text.toLowerCase();
+  if (
+    lower.includes('extra usage') ||
+    lower.includes('usage has been disabled') ||
+    lower.includes('billing_error') ||
+    lower.includes('usage limit')
+  ) {
+    const wake = nextHourBoundary() + 5 * 60 * 1000;
+    return {
+      detected: true,
+      reason: 'usage_exhausted',
+      retryAfterMs: wake - Date.now(),
+      humanMessage: `⏸ Claude usage limit reached. Will auto-resume at ${new Date(wake).toUTCString()}. I'll message you when it's back.`,
+    };
+  }
+  if (lower.includes('rate limit') || lower.includes('overloaded')) {
+    return {
+      detected: true,
+      reason: 'rate_limit',
+      retryAfterMs: 2 * 60 * 1000,
+      humanMessage: `⏸ Rate limited. Retrying in 2 minutes...`,
+    };
+  }
+  return { detected: false, reason: 'rate_limit', retryAfterMs: 0, humanMessage: '' };
+}
+
+function nextHourBoundary(): number {
+  const d = new Date();
+  d.setHours(d.getHours() + 1, 0, 0, 0);
+  return d.getTime();
+}


### PR DESCRIPTION
Detects usage limit exhaustion, notifies user via Telegram, auto-resumes when limit resets.

## Changes

- `src/usage-limit.ts` — `detectUsageLimit()` distinguishes `usage_exhausted` (sleep until next hour boundary + 5 min) from `rate_limit` (retry in 2 min)
- `src/bot.ts` — intercepts usage limit signals in result messages, sends Telegram notification, schedules retry with `setTimeout`, prepends "✅ Claude is back!" on success; `/status` shows sleeping request count; max 3 retries
- `src/usage-limit.test.ts` — 9 tests covering all detection cases and retry timing

## Test plan

- [ ] All 94 existing tests pass
- [ ] `detectUsageLimit` correctly identifies usage/rate limit phrases
- [ ] Wake time is next hour boundary + 5 min
- [ ] Rate limit retries in 2 minutes
- [ ] After 3 failed retries, sends failure notice and stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)