### PR TITLE
feat: Telegram MarkdownV2 output formatter (#19)

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -13,6 +13,7 @@ import http from "http";
 import { ClaudeProcess, extractText, ClaudeMessage, UsageEvent } from "./claude.js";
 import { transcribeVoice, isVoiceAvailable } from "./voice.js";
 import { CronManager } from "./cron.js";
+import { formatForTelegram, splitLongMessage } from "./formatter.js";
 import { detectUsageLimit } from "./usage-limit.js";
 
 const BOT_COMMANDS: Array<{ command: string; description: string }> = [
@@ -591,11 +592,12 @@ export class CcTgBot {
     const text = session.isRetry ? `✅ Claude is back!\n\n${raw}` : raw;
     session.isRetry = false;
 
-    // Telegram max message length is 4096 chars — split if needed
-    const chunks = splitMessage(text);
+    // Format for Telegram MarkdownV2 and split if needed (max 4096 chars)
+    const formatted = formatForTelegram(text);
+    const chunks = splitLongMessage(formatted);
     for (const chunk of chunks) {
-      this.bot.sendMessage(chatId, chunk, { parse_mode: "Markdown" }).catch(() => {
-        // Markdown parse failed — retry as plain text
+      this.bot.sendMessage(chatId, chunk, { parse_mode: "MarkdownV2" }).catch(() => {
+        // MarkdownV2 parse failed — retry as plain text
         this.bot.sendMessage(chatId, chunk).catch((err) =>
           console.error(`[tg:${chatId}] send failed:`, err.message)
         );
@@ -826,13 +828,19 @@ export class CcTgBot {
           } catch (err) {
             console.error(`[cron] cost footer error:`, (err as Error).message);
           }
-          const chunks = splitMessage(`🕐 ${result}${footer}`);
+          const cronFormatted = formatForTelegram(`🕐 ${result}${footer}`);
+          const chunks = splitLongMessage(cronFormatted);
           (async () => {
             for (const chunk of chunks) {
               try {
-                await this.bot.sendMessage(chatId, chunk);
-              } catch (err) {
-                console.error(`[cron] failed to send result to chat=${chatId}:`, (err as Error).message);
+                await this.bot.sendMessage(chatId, chunk, { parse_mode: "MarkdownV2" });
+              } catch {
+                // MarkdownV2 parse failed — retry as plain text
+                try {
+                  await this.bot.sendMessage(chatId, chunk);
+                } catch (err) {
+                  console.error(`[cron] failed to send result to chat=${chatId}:`, (err as Error).message);
+                }
               }
             }
           })();

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest";
+import { formatForTelegram, splitLongMessage } from "./formatter.js";
+
+describe("formatForTelegram", () => {
+  describe("headings → bold", () => {
+    it("converts ## heading to *bold*", () => {
+      expect(formatForTelegram("## Hello World")).toBe("*Hello World*");
+    });
+
+    it("converts # h1 to *bold*", () => {
+      expect(formatForTelegram("# Title")).toBe("*Title*");
+    });
+
+    it("converts ### h3 to *bold*", () => {
+      expect(formatForTelegram("### Section")).toBe("*Section*");
+    });
+
+    it("converts h6 to *bold*", () => {
+      expect(formatForTelegram("###### Deep")).toBe("*Deep*");
+    });
+
+    it("only converts headings at start of line", () => {
+      const input = "text ## not a heading";
+      // ## not at line start — should not be converted, # gets escaped
+      const result = formatForTelegram(input);
+      expect(result).not.toContain("*not a heading*");
+    });
+  });
+
+  describe("bold conversion", () => {
+    it("converts **bold** to *bold*", () => {
+      expect(formatForTelegram("**bold text**")).toBe("*bold text*");
+    });
+
+    it("converts multiple bold spans", () => {
+      const result = formatForTelegram("**foo** and **bar**");
+      expect(result).toBe("*foo* and *bar*");
+    });
+
+    it("converts bold spanning multiple words", () => {
+      expect(formatForTelegram("**hello world**")).toBe("*hello world*");
+    });
+  });
+
+  describe("bullet conversion", () => {
+    it("converts - item to • item", () => {
+      expect(formatForTelegram("- first item")).toBe("• first item");
+    });
+
+    it("converts multiple list items", () => {
+      const input = "- alpha\n- beta\n- gamma";
+      const result = formatForTelegram(input);
+      expect(result).toBe("• alpha\n• beta\n• gamma");
+    });
+
+    it("converts * bullet to • item", () => {
+      expect(formatForTelegram("* star bullet")).toBe("• star bullet");
+    });
+
+    it("handles indented list items", () => {
+      expect(formatForTelegram("  - indented")).toBe("• indented");
+    });
+  });
+
+  describe("special char escaping", () => {
+    it("escapes periods", () => {
+      expect(formatForTelegram("Hello.")).toBe("Hello\\.");
+    });
+
+    it("escapes exclamation marks", () => {
+      expect(formatForTelegram("Hello!")).toBe("Hello\\!");
+    });
+
+    it("escapes parentheses", () => {
+      expect(formatForTelegram("(test)")).toBe("\\(test\\)");
+    });
+
+    it("escapes hyphens in text", () => {
+      expect(formatForTelegram("well-known")).toBe("well\\-known");
+    });
+
+    it("escapes equals signs", () => {
+      expect(formatForTelegram("a = b")).toBe("a \\= b");
+    });
+
+    it("escapes plus signs", () => {
+      expect(formatForTelegram("a + b")).toBe("a \\+ b");
+    });
+
+    it("escapes curly braces", () => {
+      expect(formatForTelegram("{key}")).toBe("\\{key\\}");
+    });
+
+    it("escapes greater-than", () => {
+      expect(formatForTelegram("> quote")).toBe("\\> quote");
+    });
+
+    it("escapes hash outside headings", () => {
+      expect(formatForTelegram("color #fff")).toBe("color \\#fff");
+    });
+
+    it("escapes pipe", () => {
+      expect(formatForTelegram("a | b")).toBe("a \\| b");
+    });
+
+    it("escapes tilde", () => {
+      expect(formatForTelegram("~approx")).toBe("\\~approx");
+    });
+
+    it("escapes square brackets", () => {
+      expect(formatForTelegram("[link]")).toBe("\\[link\\]");
+    });
+
+    it("escapes underscore", () => {
+      expect(formatForTelegram("my_var")).toBe("my\\_var");
+    });
+
+    it("escapes backslash", () => {
+      expect(formatForTelegram("C:\\path")).toBe("C:\\\\path");
+    });
+  });
+
+  describe("code block preservation", () => {
+    it("does not escape chars inside fenced code blocks", () => {
+      const input = "```\nhello.world (test) + more!\n```";
+      const result = formatForTelegram(input);
+      expect(result).toBe("```\nhello.world (test) + more!\n```");
+    });
+
+    it("does not escape chars inside inline code", () => {
+      const input = "`my_var.method()`";
+      const result = formatForTelegram(input);
+      expect(result).toBe("`my_var.method()`");
+    });
+
+    it("escapes outside code but not inside", () => {
+      const input = "before (code) `my_var.x` after (end)";
+      const result = formatForTelegram(input);
+      expect(result).toBe("before \\(code\\) `my_var.x` after \\(end\\)");
+    });
+
+    it("preserves code block with language tag", () => {
+      const input = "```typescript\nconst x: Foo = bar();\n```";
+      const result = formatForTelegram(input);
+      expect(result).toBe("```typescript\nconst x: Foo = bar();\n```");
+    });
+
+    it("does not convert - bullets inside code blocks", () => {
+      const input = "```\n- not a bullet\n```";
+      expect(formatForTelegram(input)).toBe("```\n- not a bullet\n```");
+    });
+  });
+
+  describe("html stripping", () => {
+    it("strips HTML tags", () => {
+      expect(formatForTelegram("<b>bold</b>")).toBe("bold");
+    });
+
+    it("strips multiple tags", () => {
+      expect(formatForTelegram("<p>Hello <em>world</em></p>")).toBe("Hello world");
+    });
+  });
+
+  describe("--- conversion", () => {
+    it("converts --- to blank line", () => {
+      const input = "above\n---\nbelow";
+      const result = formatForTelegram(input);
+      expect(result).toBe("above\n\nbelow");
+    });
+  });
+
+  describe("combined", () => {
+    it("handles heading with special chars", () => {
+      const result = formatForTelegram("## My Heading - With Dash");
+      expect(result).toBe("*My Heading \\- With Dash*");
+    });
+
+    it("handles bold with special chars", () => {
+      const result = formatForTelegram("**hello.world**");
+      expect(result).toBe("*hello\\.world*");
+    });
+  });
+});
+
+describe("splitLongMessage", () => {
+  it("returns single chunk for short messages", () => {
+    const result = splitLongMessage("short message");
+    expect(result).toEqual(["short message"]);
+  });
+
+  it("returns single chunk at exactly maxLen", () => {
+    const text = "a".repeat(4096);
+    expect(splitLongMessage(text)).toHaveLength(1);
+  });
+
+  it("splits long messages", () => {
+    const text = "a".repeat(4097);
+    const chunks = splitLongMessage(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("splits at paragraph boundary", () => {
+    const para1 = "a".repeat(3000);
+    const para2 = "b".repeat(3000);
+    const text = `${para1}\n\n${para2}`;
+    const chunks = splitLongMessage(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(para1);
+    expect(chunks[1]).toBe(para2);
+  });
+
+  it("splits at line boundary when no paragraph break fits", () => {
+    const line1 = "a".repeat(3000);
+    const line2 = "b".repeat(3000);
+    const text = `${line1}\n${line2}`;
+    const chunks = splitLongMessage(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(line1);
+    expect(chunks[1]).toBe(line2);
+  });
+
+  it("splits at word boundary when no newline fits", () => {
+    const word1 = "a".repeat(3000);
+    const word2 = "b".repeat(3000);
+    const text = `${word1} ${word2}`;
+    const chunks = splitLongMessage(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(word1);
+    expect(chunks[1]).toBe(word2);
+  });
+
+  it("never produces empty chunks for normal input", () => {
+    const text = "Hello world.\n\nParagraph two.\n\nParagraph three.";
+    const chunks = splitLongMessage(text, 20);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("respects custom maxLen", () => {
+    const text = "Hello world";
+    const chunks = splitLongMessage(text, 5);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("reassembles to original content", () => {
+    const text = "First paragraph here.\n\nSecond paragraph here.\n\nThird paragraph here.";
+    const chunks = splitLongMessage(text, 30);
+    const rejoined = chunks.join("\n\n");
+    // All content should be present (whitespace may differ due to trimming)
+    expect(rejoined).toContain("First paragraph here");
+    expect(rejoined).toContain("Second paragraph here");
+    expect(rejoined).toContain("Third paragraph here");
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,101 @@
+/**
+ * Telegram MarkdownV2 post-processor.
+ * Converts standard markdown to Telegram's MarkdownV2 format.
+ */
+
+/**
+ * Convert standard markdown text to Telegram MarkdownV2 format.
+ *
+ * Processing order:
+ * 1. Extract code blocks (fenced + inline) — protect from further processing
+ * 2. Strip raw HTML tags
+ * 3. Convert --- → blank line
+ * 4. Convert ## headings → *bold*
+ * 5. Convert **bold** → *bold*
+ * 6. Convert - list items → • item
+ * 7. Escape MarkdownV2 special chars (outside code blocks)
+ * 8. Reinsert code blocks unchanged
+ */
+export function formatForTelegram(text: string): string {
+  // Step 1: Extract code blocks and inline code to protect them
+  const placeholders: string[] = [];
+
+  // Fenced code blocks first (``` ... ```)
+  let out = text.replace(/```[\s\S]*?```/g, (match) => {
+    placeholders.push(match);
+    return `\x00P${placeholders.length - 1}\x00`;
+  });
+
+  // Inline code (`...`)
+  out = out.replace(/`[^`\n]+`/g, (match) => {
+    placeholders.push(match);
+    return `\x00P${placeholders.length - 1}\x00`;
+  });
+
+  // Step 2: Strip raw HTML tags
+  out = out.replace(/<[^>]+>/g, "");
+
+  // Step 3: Convert --- → blank line
+  out = out.replace(/^-{3,}$/gm, "");
+
+  // Step 4: Convert ## headings → *bold*
+  out = out.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
+
+  // Step 5: Convert **bold** → *bold*
+  out = out.replace(/\*\*(.+?)\*\*/gs, "*$1*");
+
+  // Step 6: Convert - list items → • item (leading - or * bullet)
+  out = out.replace(/^[ \t]*[-*]\s+(.+)$/gm, "• $1");
+
+  // Step 7: Escape MarkdownV2 special chars outside code blocks.
+  // Per Telegram spec, these must be escaped: _ [ ] ( ) ~ > # + - = | { } . ! \
+  // * is intentionally NOT escaped — it is used for bold formatting above.
+  out = out.replace(/([_\[\]()~>#+\-=|{}.!\\])/g, "\\$1");
+
+  // Step 8: Reinsert code blocks unchanged (no escaping inside them)
+  out = out.replace(/\x00P(\d+)\x00/g, (_, i) => placeholders[parseInt(i, 10)]);
+
+  return out;
+}
+
+/**
+ * Split a long message at natural boundaries (paragraph > line > word).
+ * Never splits mid-word. Chunks are at most maxLen characters.
+ */
+export function splitLongMessage(text: string, maxLen = 4096): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLen) {
+    const slice = remaining.slice(0, maxLen);
+
+    // Prefer paragraph boundary (\n\n)
+    const lastPara = slice.lastIndexOf("\n\n");
+    // Then line boundary (\n)
+    const lastLine = slice.lastIndexOf("\n");
+    // Then word boundary (space)
+    const lastSpace = slice.lastIndexOf(" ");
+
+    let splitAt: number;
+    if (lastPara > 0) {
+      splitAt = lastPara + 2;
+    } else if (lastLine > 0) {
+      splitAt = lastLine + 1;
+    } else if (lastSpace > 0) {
+      splitAt = lastSpace + 1;
+    } else {
+      splitAt = maxLen;
+    }
+
+    chunks.push(remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
## Summary

- Adds `formatForTelegram()` post-processor converting standard markdown to Telegram MarkdownV2 format
- Adds `splitLongMessage()` that splits at paragraph/line/word boundaries (never mid-word)
- Updates `flushPending()` and cron result sending in `bot.ts` to use `parse_mode: 'MarkdownV2'`
- Converts headings (`##`) → `*bold*`, `**bold**` → `*bold*`, `- items` → `• items`, `---` → blank line
- Escapes all MarkdownV2 special chars outside code blocks; code blocks are passed through unchanged
- Strips raw HTML tags

## Test plan

- [x] `npm test` — all 139 tests pass across 5 test files
- [x] `src/formatter.test.ts` covers: headings→bold, bold conversion, bullet conversion, special char escaping, code block preservation, long message splitting

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)