### PR TITLE
fix: route meta-chat messages to meta-agent when one is running

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -11,6 +11,7 @@ const mockDuplicate = vi.fn();
 const mockLpush = vi.fn().mockResolvedValue(1);
 const mockLtrim = vi.fn().mockResolvedValue("OK");
 const mockPublish = vi.fn().mockResolvedValue(1);
+const mockGet = vi.fn().mockResolvedValue(null);
 
 vi.mock("ioredis", () => {
   function MockRedis(this: Record<string, unknown>) {
@@ -20,6 +21,7 @@ vi.mock("ioredis", () => {
     this.lpush = mockLpush;
     this.ltrim = mockLtrim;
     this.publish = mockPublish;
+    this.get = mockGet;
   }
   return { Redis: MockRedis };
 });
@@ -37,6 +39,7 @@ function makeRedis(): ReturnType<typeof makeBot> & {
   lpush: typeof mockLpush;
   ltrim: typeof mockLtrim;
   publish: typeof mockPublish;
+  get: typeof mockGet;
 } {
   const sub = {
     subscribe: mockSubscribe,
@@ -44,6 +47,7 @@ function makeRedis(): ReturnType<typeof makeBot> & {
     lpush: mockLpush,
     ltrim: mockLtrim,
     publish: mockPublish,
+    get: mockGet,
   };
   mockDuplicate.mockReturnValue(sub);
   return {
@@ -54,18 +58,21 @@ function makeRedis(): ReturnType<typeof makeBot> & {
     lpush: mockLpush,
     ltrim: mockLtrim,
     publish: mockPublish,
+    get: mockGet,
   };
 }
 
 describe("startNotifier", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGet.mockResolvedValue(null); // default: no meta-agent running
     const sub = {
       subscribe: mockSubscribe,
       on: mockOn,
       lpush: mockLpush,
       ltrim: mockLtrim,
       publish: mockPublish,
+      get: mockGet,
     };
     mockDuplicate.mockReturnValue(sub);
   });
@@ -99,7 +106,7 @@ describe("startNotifier", () => {
     expect(bot.sendMessage).toHaveBeenCalledWith(456, "Job done: my-task");
   });
 
-  it("echoes UI messages to Telegram and calls handleUserMessage", () => {
+  it("echoes UI messages to Telegram and calls handleUserMessage", async () => {
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
@@ -115,11 +122,13 @@ describe("startNotifier", () => {
 
     messageHandler!("cca:chat:incoming:ns1", "hello from UI");
 
+    await new Promise((r) => setTimeout(r, 0));
+
     expect(bot.sendMessage).toHaveBeenCalledWith(789, "📱 [from UI]: hello from UI");
     expect(handleUserMessage).toHaveBeenCalledWith(789, "hello from UI");
   });
 
-  it("parses JSON content from incoming UI message", () => {
+  it("parses JSON content from incoming UI message", async () => {
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
@@ -134,6 +143,8 @@ describe("startNotifier", () => {
     startNotifier(bot as never, 111, "x", redis as never, handleUserMessage);
 
     messageHandler!("cca:chat:incoming:x", JSON.stringify({ content: "extracted content" }));
+
+    await new Promise((r) => setTimeout(r, 0));
 
     expect(bot.sendMessage).toHaveBeenCalledWith(111, "📱 [from UI]: extracted content");
     expect(handleUserMessage).toHaveBeenCalledWith(111, "extracted content");
@@ -198,7 +209,7 @@ describe("startNotifier", () => {
     expect(bot.sendMessage).not.toHaveBeenCalled();
   });
 
-  it("uses getActiveChatId when chatId is null (dynamic chat bridge mode)", () => {
+  it("uses getActiveChatId when chatId is null (dynamic chat bridge mode)", async () => {
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
@@ -214,6 +225,8 @@ describe("startNotifier", () => {
     startNotifier(bot as never, null, "dyn", redis as never, handleUserMessage, getActiveChatId);
 
     messageHandler!("cca:chat:incoming:dyn", "hello dynamic");
+
+    await new Promise((r) => setTimeout(r, 0));
 
     expect(getActiveChatId).toHaveBeenCalled();
     expect(bot.sendMessage).toHaveBeenCalledWith(42, "📱 [from UI]: hello dynamic");
@@ -235,6 +248,87 @@ describe("startNotifier", () => {
 
     messageHandler!("cca:notify:dyn", "Job done");
     expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("routes to meta-agent input queue when meta-agent is running", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    mockGet.mockResolvedValue(JSON.stringify({ status: "running" }));
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 100, "ns-meta", redis as never, handleUserMessage);
+
+    messageHandler!("cca:chat:incoming:ns-meta", "hello meta");
+
+    // Give the async IIFE time to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockGet).toHaveBeenCalledWith("cca:meta-agent:status:ns-meta");
+    expect(mockLpush).toHaveBeenCalledWith(
+      "cca:meta:ns-meta:input",
+      expect.stringContaining('"content":"hello meta"')
+    );
+    expect(handleUserMessage).not.toHaveBeenCalled();
+    // Still echoes to Telegram
+    expect(bot.sendMessage).toHaveBeenCalledWith(100, "📱 [from UI]: hello meta");
+  });
+
+  it("falls back to handleUserMessage when meta-agent status is not running", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    mockGet.mockResolvedValue(JSON.stringify({ status: "idle" }));
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 200, "ns-idle", redis as never, handleUserMessage);
+
+    messageHandler!("cca:chat:incoming:ns-idle", "hello coord");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handleUserMessage).toHaveBeenCalledWith(200, "hello coord");
+    expect(mockLpush).not.toHaveBeenCalledWith(
+      "cca:meta:ns-idle:input",
+      expect.anything()
+    );
+  });
+
+  it("falls back to handleUserMessage when meta-agent status check throws", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    mockGet.mockRejectedValue(new Error("redis connection lost"));
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 300, "ns-err", redis as never, handleUserMessage);
+
+    messageHandler!("cca:chat:incoming:ns-err", "error fallback");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handleUserMessage).toHaveBeenCalledWith(300, "error fallback");
   });
 
   it("does not call handleUserMessage when getActiveChatId returns undefined", () => {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -150,10 +150,32 @@ export function startNotifier(
         };
         writeChatLog(redis, namespace, inMsg);
 
-        // Feed into active Claude session as if user typed it
-        if (handleUserMessage) {
-          handleUserMessage(targetChatId, content);
-        }
+        // Check if a meta-agent is running for this namespace; if so, route there instead
+        void (async () => {
+          let routedToMetaAgent = false;
+          try {
+            const statusRaw = await redis.get(`cca:meta-agent:status:${namespace}`);
+            if (statusRaw) {
+              const status = JSON.parse(statusRaw) as { status?: string };
+              if (status.status === "running") {
+                const entry = JSON.stringify({
+                  id: crypto.randomUUID(),
+                  content,
+                  timestamp: new Date().toISOString(),
+                });
+                await redis.lpush(`cca:meta:${namespace}:input`, entry);
+                log("info", `cca:chat:incoming: routed to meta-agent for namespace ${namespace}`);
+                routedToMetaAgent = true;
+              }
+            }
+          } catch (err) {
+            log("warn", "meta-agent status check failed, falling back to coordinator:", (err as Error).message);
+          }
+
+          if (!routedToMetaAgent && handleUserMessage) {
+            handleUserMessage(targetChatId, content);
+          }
+        })();
       } else {
         log("warn", "cca:chat:incoming: no active chatId to route message to");
       }


### PR DESCRIPTION
## Summary

- When a meta-agent is running for a namespace (`cca:meta-agent:status:{ns}` has `status=running`), incoming UI chat messages are pushed to `cca:meta:{ns}:input` instead of being routed to the coordinator via `handleUserMessage`
- Still echoes the message to Telegram and writes to the chat log in both paths
- Falls back to existing coordinator routing on redis error or when no meta-agent is running
- UUID for meta-agent input entries uses `crypto.randomUUID()` (Node.js built-in, no new deps)

## Test plan

- [x] New test: meta-agent running → lpush to `cca:meta:{ns}:input`, no `handleUserMessage` call
- [x] New test: meta-agent status not `running` → falls back to `handleUserMessage`
- [x] New test: redis.get throws → falls back to `handleUserMessage`
- [x] Existing tests updated to be async (handler is now inside a void async IIFE)
- [x] All 375 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)