### PR TITLE
fix: poll and drain cca:notify Redis list every 5s

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,41 @@
+# Plan: Poll and drain cca:notify:{namespace} Redis LIST
+
+## Task restatement
+Jobs push notifications to Redis as a LIST (`RPUSH cca:notify:{namespace}`). cc-tg's notifier only
+subscribes to pub/sub channels. We need to add a 5-second polling loop that RPOP-drains this list
+and delivers each message to Telegram.
+
+## Approaches considered
+
+### A. Poller inside `startNotifier` (chosen)
+Add `setInterval(..., 5_000)` inside the existing `startNotifier` function. Uses the main `redis`
+client (not the sub duplicate, which is in subscribe mode). Clean, minimal surface area.
+
+### B. Separate `startListPoller` export
+Create a new exported function. Would require a caller change in `index.ts`. More flexible but more
+surface area — not needed here.
+
+### C. BLPOP blocking pop in a loop
+Uses a dedicated Redis connection. Reacts instantly but complexity is higher; the 5s polling
+interval is acceptable per the spec.
+
+## Chosen approach: A
+Minimal change — add the polling loop directly inside `startNotifier`. The original `redis` param
+is in normal mode and supports RPOP. No API change to callers.
+
+## Algorithm
+1. Every 5s, call `redis.rpop(cca:notify:{namespace})` in a loop (up to 20 items).
+2. If we drained all 20 slots, call `redis.llen(key)` to count remaining items.
+3. Parse each item as JSON `{"text":"..."}`, fall back to raw string.
+4. Send each text to Telegram (`bot.sendMessage`).
+5. If remaining > 0, send `...and N more notifications` summary.
+6. Resolve chatId same way as the existing pub/sub handler: `chatId ?? getActiveChatId?.()`.
+7. If no chatId available, skip silently.
+
+## Files to touch
+- `src/notifier.ts` — add poller inside `startNotifier`
+- `src/notifier.test.ts` — add tests for poller behavior
+
+## Risks / unknowns
+- `rpop` returns `string | null` in ioredis v4+ — need to verify type
+- fake timers + async in vitest: use `vi.advanceTimersByTimeAsync` to flush microtasks

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# TODO
+
+- [x] Write PLAN.md and TODO.md
+- [ ] Implement LIST poller in src/notifier.ts
+- [ ] Add tests for the poller in src/notifier.test.ts
+- [ ] Run tests (`npm test`) and build (`npm run build`)
+- [ ] Bump version (`npm version patch`) and create PR
+- [ ] Merge PR (`gh pr merge --squash --auto`) and publish (`npm publish --access public`)
+- [ ] Push notification to redis confirming fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.17",
+  "version": "0.9.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.17",
+      "version": "0.9.19",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.17",
+  "version": "0.9.19",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { startNotifier, writeChatLog, type ChatMessage } from "./notifier.js";
 
 // ---- ioredis mock ----
@@ -12,6 +12,8 @@ const mockLpush = vi.fn().mockResolvedValue(1);
 const mockLtrim = vi.fn().mockResolvedValue("OK");
 const mockPublish = vi.fn().mockResolvedValue(1);
 const mockGet = vi.fn().mockResolvedValue(null);
+const mockRpop = vi.fn().mockResolvedValue(null);
+const mockLlen = vi.fn().mockResolvedValue(0);
 
 vi.mock("ioredis", () => {
   function MockRedis(this: Record<string, unknown>) {
@@ -22,6 +24,8 @@ vi.mock("ioredis", () => {
     this.ltrim = mockLtrim;
     this.publish = mockPublish;
     this.get = mockGet;
+    this.rpop = mockRpop;
+    this.llen = mockLlen;
   }
   return { Redis: MockRedis };
 });
@@ -40,6 +44,8 @@ function makeRedis(): ReturnType<typeof makeBot> & {
   ltrim: typeof mockLtrim;
   publish: typeof mockPublish;
   get: typeof mockGet;
+  rpop: typeof mockRpop;
+  llen: typeof mockLlen;
 } {
   const sub = {
     subscribe: mockSubscribe,
@@ -59,6 +65,8 @@ function makeRedis(): ReturnType<typeof makeBot> & {
     ltrim: mockLtrim,
     publish: mockPublish,
     get: mockGet,
+    rpop: mockRpop,
+    llen: mockLlen,
   };
 }
 
@@ -66,6 +74,8 @@ describe("startNotifier", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGet.mockResolvedValue(null); // default: no meta-agent running
+    mockRpop.mockResolvedValue(null); // default: empty list
+    mockLlen.mockResolvedValue(0);
     const sub = {
       subscribe: mockSubscribe,
       on: mockOn,
@@ -350,6 +360,156 @@ describe("startNotifier", () => {
 
     expect(bot.sendMessage).not.toHaveBeenCalled();
     expect(handleUserMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("notify list poller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGet.mockResolvedValue(null);
+    mockRpop.mockResolvedValue(null);
+    mockLlen.mockResolvedValue(0);
+    const sub = {
+      subscribe: mockSubscribe,
+      on: mockOn,
+      lpush: mockLpush,
+      ltrim: mockLtrim,
+      publish: mockPublish,
+      get: mockGet,
+    };
+    mockDuplicate.mockReturnValue(sub);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not send anything when the list is empty", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    mockRpop.mockResolvedValue(null);
+
+    startNotifier(bot as never, 123, "ns-poll", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("drains list items and sends them to Telegram", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    // Two items then empty
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "First notification" }))
+      .mockResolvedValueOnce(JSON.stringify({ text: "Second notification" }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 555, "ns-drain", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "First notification");
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "Second notification");
+    expect(bot.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends raw string when item is not JSON", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce("plain text notification")
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 777, "ns-raw", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(777, "plain text notification");
+  });
+
+  it("sends '...and N more' summary when list exceeds 20 items", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    // Return 20 items then null to fill the cycle, leaving 5 more in the list
+    const items = Array.from({ length: 20 }, (_, i) => JSON.stringify({ text: `msg ${i + 1}` }));
+    mockRpop.mockImplementation(() => {
+      const item = items.shift();
+      return Promise.resolve(item ?? null);
+    });
+    mockLlen.mockResolvedValue(5);
+
+    startNotifier(bot as never, 888, "ns-overflow", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // 20 messages + 1 summary
+    expect(bot.sendMessage).toHaveBeenCalledTimes(21);
+    expect(bot.sendMessage).toHaveBeenLastCalledWith(888, "...and 5 more notifications");
+  });
+
+  it("does not send summary when exactly 20 items and list is now empty", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    const items = Array.from({ length: 20 }, (_, i) => JSON.stringify({ text: `msg ${i + 1}` }));
+    mockRpop.mockImplementation(() => {
+      const item = items.shift();
+      return Promise.resolve(item ?? null);
+    });
+    mockLlen.mockResolvedValue(0);
+
+    startNotifier(bot as never, 999, "ns-exact20", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(20);
+    expect(bot.sendMessage).not.toHaveBeenCalledWith(999, expect.stringContaining("more notifications"));
+  });
+
+  it("skips polling when no chatId is available", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop.mockResolvedValueOnce(JSON.stringify({ text: "hello" })).mockResolvedValue(null);
+
+    startNotifier(bot as never, null, "ns-noid", redis as never, undefined, () => undefined);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses getActiveChatId when chatId is null", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "dynamic notify" }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, null, "ns-dynamic", redis as never, undefined, () => 42);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "dynamic notify");
+  });
+
+  it("continues gracefully when rpop throws", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop.mockRejectedValue(new Error("connection lost"));
+
+    startNotifier(bot as never, 123, "ns-err", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -102,6 +102,62 @@ export function startNotifier(
     }
   });
 
+  // Poll the cca:notify:{namespace} LIST every 5 seconds.
+  // Jobs push to this list via RPUSH; pub/sub alone won't deliver those messages.
+  const notifyListKey = `cca:notify:${namespace}`;
+  const MAX_PER_CYCLE = 20;
+
+  const pollNotifyList = async (): Promise<void> => {
+    const targetId = chatId ?? getActiveChatId?.();
+    if (targetId == null) return;
+
+    const items: string[] = [];
+    try {
+      for (let i = 0; i < MAX_PER_CYCLE; i++) {
+        const item = await redis.rpop(notifyListKey);
+        if (item === null) break;
+        items.push(item);
+      }
+    } catch (err) {
+      log("warn", "notify list rpop failed:", (err as Error).message);
+      return;
+    }
+
+    if (items.length === 0) return;
+
+    let remaining = 0;
+    if (items.length === MAX_PER_CYCLE) {
+      try {
+        remaining = await redis.llen(notifyListKey);
+      } catch (err) {
+        log("warn", "notify list llen failed:", (err as Error).message);
+      }
+    }
+
+    for (const raw of items) {
+      let text = raw;
+      try {
+        const parsed = JSON.parse(raw) as { text?: string };
+        if (parsed.text) text = parsed.text;
+      } catch {
+        // not JSON — use raw string as-is
+      }
+      bot.sendMessage(targetId, text).catch((err: Error) => {
+        log("warn", "notify list sendMessage failed:", err.message);
+      });
+    }
+
+    if (remaining > 0) {
+      bot.sendMessage(targetId, `...and ${remaining} more notifications`).catch((err: Error) => {
+        log("warn", "notify list summary sendMessage failed:", err.message);
+      });
+    }
+  };
+
+  setInterval(() => {
+    void pollNotifyList();
+  }, 5_000);
+
   sub.on("message", (channel: string, message: string) => {
     const notifyChannel = `cca:notify:${namespace}`;
     const incomingChannel = `cca:chat:incoming:${namespace}`;


### PR DESCRIPTION
## Summary
- Jobs (e.g. white-hat scanner, polly-gamba) push notifications to `cca:notify:{namespace}` as a Redis **LIST** via `RPUSH`, but cc-tg only consumed the pub/sub channel — so those messages were never delivered
- Added a 5-second polling loop inside `startNotifier` that RPOP-drains `cca:notify:{namespace}` using the main Redis client (not the sub duplicate which is in subscribe mode)
- Parses each item as `{"text":"..."}` (falls back to raw string); sends up to 20 messages per cycle with a `...and N more notifications` summary if the list overflows
- 7 new unit tests covering: empty list, drain, raw strings, 20-item cap + overflow summary, no-chatId skip, dynamic chatId, and rpop error handling

## Test plan
- [x] All 383 tests pass (`npx vitest run`)
- [x] Build passes (`npm run build`)
- [x] New describe block "notify list poller" covers all poller edge cases with fake timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)