### PR TITLE
feat: multi-agent driver pass-through + /drivers command

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,41 +1,42 @@
-# Plan: Poll and drain cca:notify:{namespace} Redis LIST
+# Plan: Multi-Agent Driver Pass-Through + /drivers Command
 
 ## Task restatement
-Jobs push notifications to Redis as a LIST (`RPUSH cca:notify:{namespace}`). cc-tg's notifier only
-subscribes to pub/sub channels. We need to add a 5-second polling loop that RPOP-drains this list
-and delivers each message to Telegram.
+cc-agent is gaining a driver abstraction layer (supporting non-Claude LLMs like qwen, openai, etc.).
+cc-tg needs to:
+1. Read `CC_AGENT_DEFAULT_DRIVER` and `CC_AGENT_DEFAULT_MODEL` env vars
+2. Pass `agent_driver` / `agent_model` through to any `spawn_agent` / `spawn_from_profile` MCP calls
+3. Display a driver badge in job status notifications if driver is non-claude
+4. Add a `/drivers` Telegram command that calls the new `list_drivers` MCP tool
 
 ## Approaches considered
 
-### A. Poller inside `startNotifier` (chosen)
-Add `setInterval(..., 5_000)` inside the existing `startNotifier` function. Uses the main `redis`
-client (not the sub duplicate, which is in subscribe mode). Clean, minimal surface area.
+### A. Env-var injection only
+Just set CC_AGENT_DEFAULT_DRIVER in the process environment and rely on cc-agent to read it.
+Pro: zero code changes. Con: cc-tg doesn't control what args Claude Code passes to spawn_agent.
 
-### B. Separate `startListPoller` export
-Create a new exported function. Would require a caller change in `index.ts`. More flexible but more
-surface area — not needed here.
+### B. callCcAgentTool auto-injection (chosen for spawn calls)
+When cc-tg's own `callCcAgentTool` calls `spawn_agent` or `spawn_from_profile`, automatically
+merge `agent_driver` / `agent_model` into the args. ClaudeProcess already inherits all process.env
+so Claude Code (the coordinator) sees the env vars too — both paths covered.
 
-### C. BLPOP blocking pop in a loop
-Uses a dedicated Redis connection. Reacts instantly but complexity is higher; the 5s polling
-interval is acceptable per the spec.
+### C. Intercept Claude tool events and rewrite args
+Hook into the `assistant` message stream and rewrite spawn_agent args before forwarding.
+Too invasive — Claude Code formats these calls internally.
 
-## Chosen approach: A
-Minimal change — add the polling loop directly inside `startNotifier`. The original `redis` param
-is in normal mode and supports RPOP. No API change to callers.
-
-## Algorithm
-1. Every 5s, call `redis.rpop(cca:notify:{namespace})` in a loop (up to 20 items).
-2. If we drained all 20 slots, call `redis.llen(key)` to count remaining items.
-3. Parse each item as JSON `{"text":"..."}`, fall back to raw string.
-4. Send each text to Telegram (`bot.sendMessage`).
-5. If remaining > 0, send `...and N more notifications` summary.
-6. Resolve chatId same way as the existing pub/sub handler: `chatId ?? getActiveChatId?.()`.
-7. If no chatId available, skip silently.
+## Chosen approach: B
+- `callCcAgentTool`: auto-merge driver/model args for spawn tools
+- ClaudeProcess env: already inherits `process.env` (including CC_AGENT_DEFAULT_DRIVER/MODEL)
+- Notification badge: parse JSON payload in notifier, append `[model]` badge if driver != 'claude'
+- `/drivers` command: call `list_drivers` via `callCcAgentTool` and format the text result
 
 ## Files to touch
-- `src/notifier.ts` — add poller inside `startNotifier`
-- `src/notifier.test.ts` — add tests for poller behavior
+- `src/bot.ts` — BOT_COMMANDS, callCcAgentTool driver injection, /drivers handler
+- `src/notifier.ts` — driver badge in notification text
+- `src/bot.test.ts` — /drivers command test
+- `src/notifier.test.ts` — badge parsing test
 
 ## Risks / unknowns
-- `rpop` returns `string | null` in ioredis v4+ — need to verify type
-- fake timers + async in vitest: use `vi.advanceTimersByTimeAsync` to flush microtasks
+- `list_drivers` MCP tool may return raw text or JSON — handle both gracefully
+- Notification JSON format with `driver`/`model` fields is assumed (cc-agent side); badge only
+  shown if fields are present and driver != 'claude'
+- No existing spawn_agent calls in cc-tg code; callCcAgentTool injection is forward-looking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.19",
+  "version": "0.9.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.19",
+      "version": "0.9.22",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.19",
+  "version": "0.9.22",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -431,6 +431,59 @@ describe('CcTgBot', () => {
       });
     });
 
+    describe('/drivers command', () => {
+      it('lists drivers from MCP and marks default', async () => {
+        vi.spyOn(bot as any, 'callCcAgentTool').mockResolvedValue(JSON.stringify(['claude', 'openrouter']));
+        const origDriver = process.env.CC_AGENT_DEFAULT_DRIVER;
+        process.env.CC_AGENT_DEFAULT_DRIVER = 'claude';
+        await sendCommand('/drivers');
+        process.env.CC_AGENT_DEFAULT_DRIVER = origDriver;
+
+        expect(mocks.tgSendMessage).toHaveBeenCalledOnce();
+        const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+        expect(msg).toContain('claude (default)');
+        expect(msg).toContain('openrouter');
+      });
+
+      it('falls back to raw text when MCP returns non-JSON', async () => {
+        vi.spyOn(bot as any, 'callCcAgentTool').mockResolvedValue('claude\nopenrouter');
+        await sendCommand('/drivers');
+
+        const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+        expect(msg).toContain('claude');
+        expect(msg).toContain('openrouter');
+      });
+
+      it('replies with no-drivers message when MCP returns null', async () => {
+        vi.spyOn(bot as any, 'callCcAgentTool').mockResolvedValue(null);
+        await sendCommand('/drivers');
+
+        expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, 'No drivers available or cc-agent did not respond.');
+      });
+
+      it('replies with error message when MCP throws', async () => {
+        vi.spyOn(bot as any, 'callCcAgentTool').mockRejectedValue(new Error('tool not found'));
+        await sendCommand('/drivers');
+
+        const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+        expect(msg).toContain('Failed to list drivers');
+        expect(msg).toContain('tool not found');
+      });
+
+      it('/drivers marks non-claude driver as default when CC_AGENT_DEFAULT_DRIVER is set', async () => {
+        vi.spyOn(bot as any, 'callCcAgentTool').mockResolvedValue(JSON.stringify(['claude', 'openrouter', 'openai']));
+        const origDriver = process.env.CC_AGENT_DEFAULT_DRIVER;
+        process.env.CC_AGENT_DEFAULT_DRIVER = 'openrouter';
+        await sendCommand('/drivers');
+        process.env.CC_AGENT_DEFAULT_DRIVER = origDriver;
+
+        const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+        expect(msg).toContain('openrouter (default)');
+        expect(msg).toContain('claude');
+        expect(msg).not.toContain('claude (default)');
+      });
+    });
+
   });
 
   describe('trackWrittenFiles', () => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -35,6 +35,7 @@ const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "skills", description: "List available Claude skills with descriptions" },
   { command: "cron", description: "Manage cron jobs — add/list/edit/remove/clear" },
   { command: "voice_retry", description: "Retry failed voice message transcriptions" },
+  { command: "drivers", description: "List available agent drivers" },
 ];
 
 export interface BotOptions {
@@ -469,6 +470,12 @@ export class CcTgBot {
     // /voice_retry — retry failed voice message transcriptions
     if (text === "/voice_retry") {
       await this.handleVoiceRetry(chatId, threadId);
+      return;
+    }
+
+    // /drivers — list available agent drivers via cc-agent MCP
+    if (text === "/drivers") {
+      await this.handleDrivers(chatId, threadId);
       return;
     }
 
@@ -1365,7 +1372,42 @@ export class CcTgBot {
     await this.bot.sendDocument(chatId, filePath, docOpts);
   }
 
+  private async handleDrivers(chatId: number, threadId?: number): Promise<void> {
+    try {
+      const raw = await this.callCcAgentTool("list_drivers");
+      if (!raw) {
+        await this.replyToChat(chatId, "No drivers available or cc-agent did not respond.", threadId);
+        return;
+      }
+      // Try to pretty-print JSON array/object, fall back to raw string
+      let reply: string;
+      try {
+        const data = JSON.parse(raw) as unknown;
+        if (Array.isArray(data)) {
+          const current = process.env.CC_AGENT_DEFAULT_DRIVER || "claude";
+          const lines = (data as string[]).map((d) => d === current ? `• ${d} (default)` : `• ${d}`);
+          reply = `Available drivers:\n${lines.join("\n")}`;
+        } else {
+          reply = `Available drivers:\n${raw}`;
+        }
+      } catch {
+        reply = `Available drivers:\n${raw}`;
+      }
+      await this.replyToChat(chatId, reply, threadId);
+    } catch (err) {
+      await this.replyToChat(chatId, `Failed to list drivers: ${(err as Error).message}`, threadId);
+    }
+  }
+
   private callCcAgentTool(toolName: string, args: Record<string, unknown> = {}): Promise<string | null> {
+    // For spawn tools, pass through the configured driver and model
+    const spawnTools = new Set(["spawn_agent", "spawn_from_profile"]);
+    if (spawnTools.has(toolName)) {
+      const driver = process.env.CC_AGENT_DEFAULT_DRIVER || "claude";
+      const model = process.env.CC_AGENT_DEFAULT_MODEL || undefined;
+      args = { agent_driver: driver, ...(model ? { agent_model: model } : {}), ...args };
+    }
+
     return new Promise((resolve) => {
       let settled = false;
       const done = (val: string | null) => {

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { startNotifier, writeChatLog, type ChatMessage } from "./notifier.js";
+import { startNotifier, writeChatLog, parseNotification, type ChatMessage } from "./notifier.js";
 
 // ---- ioredis mock ----
 const mockSubscribe = vi.fn().mockImplementation((_channel: string, cb?: (err: Error | null) => void) => {
@@ -510,6 +510,64 @@ describe("notify list poller", () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseNotification", () => {
+  it("returns raw string when input is not JSON", () => {
+    expect(parseNotification("plain text")).toBe("plain text");
+  });
+
+  it("extracts text field from JSON", () => {
+    expect(parseNotification(JSON.stringify({ text: "Job done" }))).toBe("Job done");
+  });
+
+  it("adds no badge when driver is 'claude'", () => {
+    expect(parseNotification(JSON.stringify({ text: "Job done", driver: "claude" }))).toBe("Job done");
+  });
+
+  it("adds no badge when driver is absent", () => {
+    expect(parseNotification(JSON.stringify({ text: "Job done" }))).toBe("Job done");
+  });
+
+  it("appends model badge when driver is non-claude and model is set", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "openrouter", model: "qwen2.5-72b" }))
+    ).toBe("Job done [qwen2.5-72b]");
+  });
+
+  it("appends driver badge when driver is non-claude and model is absent", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "openai" }))
+    ).toBe("Job done [openai]");
+  });
+
+  it("appends driver badge when driver is non-claude and model is empty string", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "openai", model: "" }))
+    ).toBe("Job done [openai]");
+  });
+
+  it("returns raw string when JSON has no text field", () => {
+    expect(parseNotification(JSON.stringify({ foo: "bar" }))).toBe(JSON.stringify({ foo: "bar" }));
+  });
+
+  it("pub/sub handler uses parseNotification — JSON badge appears in sent message", () => {
+    // This is an integration check through the message handler
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+    messageHandler!("cca:notify:ns", JSON.stringify({ text: "Task done", driver: "openrouter", model: "qwen2.5-72b" }));
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "Task done [qwen2.5-72b]");
   });
 });
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -28,6 +28,34 @@ function log(level: "info" | "warn" | "error", ...args: unknown[]): void {
 }
 
 /**
+ * Parse a notification payload and return the display text.
+ * Appends a [model] or [driver] badge if the driver is non-claude.
+ *
+ * Payload format (JSON): { text: string, driver?: string, model?: string }
+ * Falls back to raw string if not valid JSON.
+ */
+export function parseNotification(raw: string): string {
+  let text = raw;
+  let driver: string | undefined;
+  let model: string | undefined;
+  try {
+    const parsed = JSON.parse(raw) as { text?: string; driver?: string; model?: string };
+    if (parsed.text) text = parsed.text;
+    driver = parsed.driver;
+    model = parsed.model;
+  } catch {
+    // not JSON — use raw string as-is, no badge
+    return text;
+  }
+
+  // Only show badge if driver is present and not 'claude'
+  if (!driver || driver === "claude") return text;
+
+  const badge = model && model.trim() ? model.trim() : driver;
+  return `${text} [${badge}]`;
+}
+
+/**
  * Write a message to the chat log in Redis.
  * Fire-and-forget — errors are logged but not thrown.
  */
@@ -135,13 +163,7 @@ export function startNotifier(
     }
 
     for (const raw of items) {
-      let text = raw;
-      try {
-        const parsed = JSON.parse(raw) as { text?: string };
-        if (parsed.text) text = parsed.text;
-      } catch {
-        // not JSON — use raw string as-is
-      }
+      const text = parseNotification(raw);
       bot.sendMessage(targetId, text).catch((err: Error) => {
         log("warn", "notify list sendMessage failed:", err.message);
       });
@@ -165,7 +187,8 @@ export function startNotifier(
     if (channel === notifyChannel) {
       const targetId = chatId ?? getActiveChatId?.();
       if (targetId != null) {
-        bot.sendMessage(targetId, message).catch((err: Error) => {
+        const text = parseNotification(message);
+        bot.sendMessage(targetId, text).catch((err: Error) => {
           log("warn", "sendMessage failed:", err.message);
         });
       } else {


### PR DESCRIPTION
## Summary

- **Driver pass-through**: `callCcAgentTool` now auto-injects `agent_driver` (default: `'claude'`) and `agent_model` (from `CC_AGENT_DEFAULT_DRIVER` / `CC_AGENT_DEFAULT_MODEL` env vars) into any `spawn_agent` or `spawn_from_profile` MCP calls
- **Driver badge in notifications**: `parseNotification` (new exported helper) appends a `[model]` or `[driver]` badge to job status messages when driver is non-claude — applied to both pub/sub and LIST poller notification paths
- **`/drivers` command**: calls the new `list_drivers` MCP tool and returns the list of available drivers, marking the current default

## Configuration

All new env vars are optional:
- `CC_AGENT_DEFAULT_DRIVER` — agent driver to use (default: `'claude'`)
- `CC_AGENT_DEFAULT_MODEL` — model override to pass through (empty = omit)

## Test plan

- [x] 397 tests passing
- [x] Build clean
- [x] 5 new /drivers tests, 9 new parseNotification tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)