### PR TITLE
feat: /cost revamp, driver+cost badges, /agents command

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,42 +1,43 @@
-# Plan: Multi-Agent Driver Pass-Through + /drivers Command
+# Plan: /cost, driver+cost badges, /agents command
 
 ## Task restatement
-cc-agent is gaining a driver abstraction layer (supporting non-Claude LLMs like qwen, openai, etc.).
-cc-tg needs to:
-1. Read `CC_AGENT_DEFAULT_DRIVER` and `CC_AGENT_DEFAULT_MODEL` env vars
-2. Pass `agent_driver` / `agent_model` through to any `spawn_agent` / `spawn_from_profile` MCP calls
-3. Display a driver badge in job status notifications if driver is non-claude
-4. Add a `/drivers` Telegram command that calls the new `list_drivers` MCP tool
+1. `/cost` — reformat `formatAgentCostSummary` to cleaner "💰 Cost Summary" layout
+2. Job completion notifications — always show driver badge (including 'claude'), add cost if present
+3. `/drivers` — already implemented, no changes needed
+4. `/agents` — new command reading Redis `cca:meta-agent:status:*` keys
 
-## Approaches considered
+## Approaches
 
-### A. Env-var injection only
-Just set CC_AGENT_DEFAULT_DRIVER in the process environment and rely on cc-agent to read it.
-Pro: zero code changes. Con: cc-tg doesn't control what args Claude Code passes to spawn_agent.
+### Change 1: /cost format
+- Update `formatAgentCostSummary` in `bot.ts` to use new heading, aligned repo costs, "No cost data available yet." fallback
+- Keep existing session cost section (📊)
 
-### B. callCcAgentTool auto-injection (chosen for spawn calls)
-When cc-tg's own `callCcAgentTool` calls `spawn_agent` or `spawn_from_profile`, automatically
-merge `agent_driver` / `agent_model` into the args. ClaudeProcess already inherits all process.env
-so Claude Code (the coordinator) sees the env vars too — both paths covered.
+### Change 2: Notification badge + cost
+- `parseNotification` in `notifier.ts`: always show badge when `driver` field is present (remove claude exception)
+- Badge format: `[driver:shortmodel]` where shortmodel strips driver prefix or vendor/ prefix
+- Add `cost: $X.XXX` suffix if `cost` field present in JSON payload
+- Update separator from space to `\n` for multi-line friendliness
+- Update affected tests in `notifier.test.ts`
 
-### C. Intercept Claude tool events and rewrite args
-Hook into the `assistant` message stream and rewrite spawn_agent args before forwarding.
-Too invasive — Claude Code formats these calls internally.
+### Change 3: /drivers
+- Already implemented (verified: `handleDrivers` at bot.ts:1375, BOT_COMMANDS entry at line 38)
+- No changes needed
 
-## Chosen approach: B
-- `callCcAgentTool`: auto-merge driver/model args for spawn tools
-- ClaudeProcess env: already inherits `process.env` (including CC_AGENT_DEFAULT_DRIVER/MODEL)
-- Notification badge: parse JSON payload in notifier, append `[model]` badge if driver != 'claude'
-- `/drivers` command: call `list_drivers` via `callCcAgentTool` and format the text result
+### Change 4: /agents
+- Add `BOT_COMMANDS` entry
+- Add `/agents` case in `handleTelegram`
+- Implement `handleAgents`: SCAN `cca:meta-agent:status:*`, GET each, format namespace+status+turns+age
+- Handle missing Redis gracefully
+- Add tests in `bot.test.ts` with mocked Redis
 
 ## Files to touch
-- `src/bot.ts` — BOT_COMMANDS, callCcAgentTool driver injection, /drivers handler
-- `src/notifier.ts` — driver badge in notification text
-- `src/bot.test.ts` — /drivers command test
-- `src/notifier.test.ts` — badge parsing test
+- `src/bot.ts` — formatAgentCostSummary, BOT_COMMANDS, handleTelegram, handleAgents
+- `src/notifier.ts` — parseNotification (badge always shown, cost support, shortenModelName helper)
+- `src/bot.test.ts` — add /agents tests
+- `src/notifier.test.ts` — update badge tests for new behavior, add cost tests
 
 ## Risks / unknowns
-- `list_drivers` MCP tool may return raw text or JSON — handle both gracefully
-- Notification JSON format with `driver`/`model` fields is assumed (cc-agent side); badge only
-  shown if fields are present and driver != 'claude'
-- No existing spawn_agent calls in cc-tg code; callCcAgentTool injection is forward-looking
+- ioredis SCAN return type: `Promise<[string, string[]]>` in ioredis v5 — should be fine
+- Cost field format from cc-agent: assuming `cost?: number` in the JSON payload
+- Redis SCAN cursor: must drain until cursor === "0"
+- `parseNotification` badge change affects existing passing tests — must update them

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.22",
+      "version": "0.9.23",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -1256,3 +1256,142 @@ describe('handleVoiceRetry', () => {
     expect(lastCall[1]).toContain('1 failed');
   });
 });
+
+describe('handleAgents', () => {
+  const mockScan = vi.fn();
+  const mockGet = vi.fn();
+
+  const mockRedis = {
+    scan: mockScan,
+    get: mockGet,
+    lpush: vi.fn().mockResolvedValue(1),
+    ltrim: vi.fn().mockResolvedValue('OK'),
+    publish: vi.fn().mockResolvedValue(1),
+  };
+
+  function makeBotWithRedis() {
+    return new CcTgBot({ telegramToken: 'test-token', redis: mockRedis as never });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.existsSyncMock.mockReturnValue(false);
+    // Default: empty scan result
+    mockScan.mockResolvedValue(['0', []]);
+    mockGet.mockResolvedValue(null);
+  });
+
+  it('replies with no-redis message when Redis not configured', async () => {
+    const bot = new CcTgBot({ telegramToken: 'test-token' });
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, 'Redis not configured — agents status unavailable.');
+  });
+
+  it('replies with no-agents message when no keys found', async () => {
+    mockScan.mockResolvedValue(['0', []]);
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, 'No active meta-agents.');
+  });
+
+  it('shows running agent with typing status', async () => {
+    mockScan.mockResolvedValue(['0', ['cca:meta-agent:status:money-brain']]);
+    mockGet.mockResolvedValue(JSON.stringify({
+      status: 'running',
+      current_tool: 'Bash',
+      turn: 42,
+    }));
+
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('🤖 Active Agents');
+    expect(msg).toContain('money-brain');
+    expect(msg).toContain('typing...');
+    expect(msg).toContain('turn 42');
+  });
+
+  it('shows idle agent with turn count and age', async () => {
+    const lastActivity = new Date(Date.now() - 3 * 60 * 1000).toISOString(); // 3 minutes ago
+    mockScan.mockResolvedValue(['0', ['cca:meta-agent:status:simorgh']]);
+    mockGet.mockResolvedValue(JSON.stringify({
+      status: 'idle',
+      turn: 8,
+      last_activity: lastActivity,
+    }));
+
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('simorgh');
+    expect(msg).toContain('idle');
+    expect(msg).toContain('turn 8');
+    expect(msg).toContain('3m ago');
+  });
+
+  it('shows multiple agents', async () => {
+    mockScan.mockResolvedValue(['0', [
+      'cca:meta-agent:status:alpha',
+      'cca:meta-agent:status:beta',
+    ]]);
+    mockGet
+      .mockResolvedValueOnce(JSON.stringify({ status: 'running', turn: 5 }))
+      .mockResolvedValueOnce(JSON.stringify({ status: 'idle', turn: 1 }));
+
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('alpha');
+    expect(msg).toContain('beta');
+  });
+
+  it('handles malformed status JSON gracefully', async () => {
+    mockScan.mockResolvedValue(['0', ['cca:meta-agent:status:broken']]);
+    mockGet.mockResolvedValue('not-valid-json{{{');
+
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('broken');
+    expect(msg).toContain('status unknown');
+  });
+
+  it('handles redis scan error gracefully', async () => {
+    mockScan.mockRejectedValue(new Error('redis unavailable'));
+    const bot = makeBotWithRedis();
+    await (bot as any).handleAgents(42);
+    bot.stop();
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('Failed to get agents status');
+    expect(msg).toContain('redis unavailable');
+  });
+
+  it('/agents command dispatches to handleAgents', async () => {
+    mockScan.mockResolvedValue(['0', []]);
+    const bot = makeBotWithRedis();
+    await (bot as any).handleTelegram({
+      chat: { id: 42, type: 'private' },
+      from: { id: 100 },
+      text: '/agents',
+      message_id: 1,
+    });
+    bot.stop();
+
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, 'No active meta-agents.');
+  });
+});

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -36,6 +36,7 @@ const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "cron", description: "Manage cron jobs — add/list/edit/remove/clear" },
   { command: "voice_retry", description: "Retry failed voice message transcriptions" },
   { command: "drivers", description: "List available agent drivers" },
+  { command: "agents", description: "Show running meta-agents and their live status" },
 ];
 
 export interface BotOptions {
@@ -124,21 +125,28 @@ function formatAgentCostSummary(text: string): string {
   try {
     const data = JSON.parse(text) as Record<string, unknown>;
     const totalCost = ((data.total_cost_usd ?? data.total_cost ?? 0) as number);
-    const totalJobs = ((data.total_jobs ?? data.job_count ?? 0) as number);
     const byRepo = (data.by_repo ?? []) as Array<Record<string, unknown>>;
-    const lines = [
-      "🤖 Agent jobs (all time)",
-      `Total: $${totalCost.toFixed(2)} across ${totalJobs} jobs`,
-    ];
+
+    if (byRepo.length === 0) {
+      return "No cost data available yet.";
+    }
+
+    const lines = ["💰 Cost Summary", ""];
+
+    // Align repo names with right-padded costs
+    const maxLen = Math.max(...byRepo.map((e) => ((e.repo ?? e.repository ?? "unknown") as string).length));
     for (const entry of byRepo) {
       const repo = (entry.repo ?? entry.repository ?? "unknown") as string;
       const cost = ((entry.cost_usd ?? entry.cost ?? 0) as number);
-      const jobs = ((entry.job_count ?? entry.jobs ?? 0) as number);
-      lines.push(`  ${repo}: $${cost.toFixed(2)} (${jobs} jobs)`);
+      const pad = " ".repeat(maxLen - repo.length + 3);
+      lines.push(`${repo}${pad}$${cost.toFixed(2)}`);
     }
+
+    lines.push("");
+    lines.push(`Total: $${totalCost.toFixed(2)}`);
     return lines.join("\n");
   } catch {
-    return `🤖 Agent jobs (all time)\n${text}`;
+    return `💰 Cost Summary\n${text}`;
   }
 }
 
@@ -476,6 +484,12 @@ export class CcTgBot {
     // /drivers — list available agent drivers via cc-agent MCP
     if (text === "/drivers") {
       await this.handleDrivers(chatId, threadId);
+      return;
+    }
+
+    // /agents — show running meta-agents and their live status
+    if (text === "/agents") {
+      await this.handleAgents(chatId, threadId);
       return;
     }
 
@@ -1396,6 +1410,82 @@ export class CcTgBot {
       await this.replyToChat(chatId, reply, threadId);
     } catch (err) {
       await this.replyToChat(chatId, `Failed to list drivers: ${(err as Error).message}`, threadId);
+    }
+  }
+
+  private async handleAgents(chatId: number, threadId?: number): Promise<void> {
+    if (!this.redis) {
+      await this.replyToChat(chatId, "Redis not configured — agents status unavailable.", threadId);
+      return;
+    }
+
+    try {
+      // Scan for all meta-agent status keys
+      const keys: string[] = [];
+      let cursor = "0";
+      do {
+        const [nextCursor, found] = await this.redis.scan(cursor, "MATCH", "cca:meta-agent:status:*", "COUNT", 100);
+        cursor = nextCursor;
+        keys.push(...found);
+      } while (cursor !== "0");
+
+      if (keys.length === 0) {
+        await this.replyToChat(chatId, "No active meta-agents.", threadId);
+        return;
+      }
+
+      const statuses = await Promise.all(
+        keys.sort().map(async (key) => ({ key, raw: await this.redis!.get(key) }))
+      );
+
+      const lines = ["🤖 Active Agents", ""];
+      for (const { key, raw } of statuses) {
+        const namespace = key.replace("cca:meta-agent:status:", "");
+        if (!raw) {
+          lines.push(`${namespace} — status unknown`);
+          continue;
+        }
+        try {
+          const status = JSON.parse(raw) as {
+            status?: string;
+            current_tool?: string;
+            turn?: number;
+            turn_count?: number;
+            last_activity?: string;
+            updated_at?: string;
+          };
+
+          const state = status.status ?? "unknown";
+          const turns = status.turn ?? status.turn_count ?? 0;
+          const tool = status.current_tool;
+          const lastActivity = status.last_activity ?? status.updated_at;
+
+          let ageStr = "";
+          if (lastActivity) {
+            const ageSec = Math.floor((Date.now() - new Date(lastActivity).getTime()) / 1000);
+            if (ageSec < 60) ageStr = `${ageSec}s ago`;
+            else if (ageSec < 3600) ageStr = `${Math.floor(ageSec / 60)}m ago`;
+            else ageStr = `${Math.floor(ageSec / 3600)}h ago`;
+          }
+
+          let statusDesc: string;
+          if (state === "running" && tool) {
+            statusDesc = `typing... (turn ${turns})`;
+          } else if (state === "running") {
+            statusDesc = `running (turn ${turns}${ageStr ? `, ${ageStr}` : ""})`;
+          } else {
+            statusDesc = `idle (turn ${turns}${ageStr ? `, ${ageStr}` : ""})`;
+          }
+
+          lines.push(`${namespace} — ${statusDesc}`);
+        } catch {
+          lines.push(`${namespace} — status unknown`);
+        }
+      }
+
+      await this.replyToChat(chatId, lines.join("\n"), threadId);
+    } catch (err) {
+      await this.replyToChat(chatId, `Failed to get agents status: ${(err as Error).message}`, threadId);
     }
   }
 

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -522,30 +522,61 @@ describe("parseNotification", () => {
     expect(parseNotification(JSON.stringify({ text: "Job done" }))).toBe("Job done");
   });
 
-  it("adds no badge when driver is 'claude'", () => {
-    expect(parseNotification(JSON.stringify({ text: "Job done", driver: "claude" }))).toBe("Job done");
+  it("adds [claude] badge when driver is 'claude'", () => {
+    expect(parseNotification(JSON.stringify({ text: "Job done", driver: "claude" }))).toBe("Job done\n[claude]");
+  });
+
+  it("strips driver prefix from model in claude badge", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "claude", model: "claude-sonnet-4-6" }))
+    ).toBe("Job done\n[claude:sonnet-4-6]");
   });
 
   it("adds no badge when driver is absent", () => {
     expect(parseNotification(JSON.stringify({ text: "Job done" }))).toBe("Job done");
   });
 
-  it("appends model badge when driver is non-claude and model is set", () => {
+  it("appends [driver:model] badge when driver and model are set", () => {
     expect(
       parseNotification(JSON.stringify({ text: "Job done", driver: "openrouter", model: "qwen2.5-72b" }))
-    ).toBe("Job done [qwen2.5-72b]");
+    ).toBe("Job done\n[openrouter:qwen2.5-72b]");
   });
 
-  it("appends driver badge when driver is non-claude and model is absent", () => {
+  it("appends driver-only badge when model is absent", () => {
     expect(
       parseNotification(JSON.stringify({ text: "Job done", driver: "openai" }))
-    ).toBe("Job done [openai]");
+    ).toBe("Job done\n[openai]");
   });
 
-  it("appends driver badge when driver is non-claude and model is empty string", () => {
+  it("appends driver-only badge when model is empty string", () => {
     expect(
       parseNotification(JSON.stringify({ text: "Job done", driver: "openai", model: "" }))
-    ).toBe("Job done [openai]");
+    ).toBe("Job done\n[openai]");
+  });
+
+  it("strips vendor/ prefix from model name", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "openrouter", model: "openai/gpt-4o" }))
+    ).toBe("Job done\n[openrouter:gpt-4o]");
+  });
+
+  it("appends cost when cost field is present", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", driver: "claude", model: "claude-sonnet-4-6", cost: 1.234 }))
+    ).toBe("Job done\n[claude:sonnet-4-6] cost: $1.234");
+  });
+
+  it("appends cost without badge when driver is absent but cost is present", () => {
+    // driver absent → no badge; cost not shown either (no driver = raw text path)
+    expect(
+      parseNotification(JSON.stringify({ text: "Job done", cost: 0.5 }))
+    ).toBe("Job done");
+  });
+
+  it("formats cost to 3 decimal places", () => {
+    expect(
+      parseNotification(JSON.stringify({ text: "Done", driver: "openai", cost: 0.04 }))
+    ).toBe("Done\n[openai] cost: $0.040");
   });
 
   it("returns raw string when JSON has no text field", () => {
@@ -567,7 +598,24 @@ describe("parseNotification", () => {
     startNotifier(bot as never, 42, "ns", redis as never);
     messageHandler!("cca:notify:ns", JSON.stringify({ text: "Task done", driver: "openrouter", model: "qwen2.5-72b" }));
 
-    expect(bot.sendMessage).toHaveBeenCalledWith(42, "Task done [qwen2.5-72b]");
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "Task done\n[openrouter:qwen2.5-72b]");
+  });
+
+  it("pub/sub handler includes cost badge", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 42, "ns2", redis as never);
+    messageHandler!("cca:notify:ns2", JSON.stringify({ text: "✅ done", driver: "claude", model: "claude-sonnet-4-6", cost: 1.23 }));
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "✅ done\n[claude:sonnet-4-6] cost: $1.230");
   });
 });
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -28,31 +28,51 @@ function log(level: "info" | "warn" | "error", ...args: unknown[]): void {
 }
 
 /**
+ * Shorten a model name for display in a badge.
+ * - Strips driver prefix (e.g. "claude-sonnet-4-6" with driver "claude" → "sonnet-4-6")
+ * - Strips vendor/ prefix for openrouter-style names (e.g. "openai/gpt-4o" → "gpt-4o")
+ * - Returns empty string when model is absent.
+ */
+function shortenModelName(model: string, driver: string): string {
+  if (!model.trim()) return "";
+  const pfx = driver.toLowerCase() + "-";
+  if (model.toLowerCase().startsWith(pfx)) return model.slice(pfx.length);
+  const slashIdx = model.indexOf("/");
+  if (slashIdx >= 0) return model.slice(slashIdx + 1);
+  return model;
+}
+
+/**
  * Parse a notification payload and return the display text.
- * Appends a [model] or [driver] badge if the driver is non-claude.
+ * Appends a [driver] or [driver:model] badge whenever the driver field is present.
+ * Appends " cost: $X.XXX" if a numeric cost field is present.
  *
- * Payload format (JSON): { text: string, driver?: string, model?: string }
+ * Payload format (JSON): { text: string, driver?: string, model?: string, cost?: number }
  * Falls back to raw string if not valid JSON.
  */
 export function parseNotification(raw: string): string {
   let text = raw;
   let driver: string | undefined;
   let model: string | undefined;
+  let cost: number | undefined;
   try {
-    const parsed = JSON.parse(raw) as { text?: string; driver?: string; model?: string };
+    const parsed = JSON.parse(raw) as { text?: string; driver?: string; model?: string; cost?: number };
     if (parsed.text) text = parsed.text;
     driver = parsed.driver;
     model = parsed.model;
+    if (typeof parsed.cost === "number") cost = parsed.cost;
   } catch {
     // not JSON — use raw string as-is, no badge
     return text;
   }
 
-  // Only show badge if driver is present and not 'claude'
-  if (!driver || driver === "claude") return text;
+  // Show badge whenever driver field is present
+  if (!driver) return text;
 
-  const badge = model && model.trim() ? model.trim() : driver;
-  return `${text} [${badge}]`;
+  const shortModel = shortenModelName(model ?? "", driver);
+  const badge = shortModel ? `${driver}:${shortModel}` : driver;
+  const costStr = cost != null ? ` cost: $${cost.toFixed(3)}` : "";
+  return `${text}\n[${badge}]${costStr}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **`/cost` command**: reformatted `formatAgentCostSummary` to cleaner `💰 Cost Summary` layout with aligned repo costs and `Total:` line; shows \"No cost data available yet.\" when empty
- **Notification badges**: `parseNotification` now always shows driver badge (including `claude`), formats as `[driver:model]` with model shortening (strips driver prefix / vendor/ prefix), appends `cost: $X.XXX` when cost field present in payload
- **`/agents` command**: new command reads `cca:meta-agent:status:*` keys from Redis, shows namespace, status (typing.../idle/running), turn count, and last-activity age
- **`/drivers`**: already implemented in prior session — no changes needed

## Test plan
- [x] All 411 tests pass (`npm test`)
- [x] Build clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)