### PR TITLE
fix: meta-agent responses not reaching Telegram

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,43 +1,25 @@
-# Plan: /cost, driver+cost badges, /agents command
+# Plan: Relay meta-agent responses from cca:chat:outgoing to Telegram
 
-## Task restatement
-1. `/cost` — reformat `formatAgentCostSummary` to cleaner "💰 Cost Summary" layout
-2. Job completion notifications — always show driver badge (including 'claude'), add cost if present
-3. `/drivers` — already implemented, no changes needed
-4. `/agents` — new command reading Redis `cca:meta-agent:status:*` keys
+## Task restated
+Meta-agent stdout lines are published per-line to `cca:chat:outgoing:{ns}` with `source: "claude"`.
+cc-tg currently never subscribes to this channel. Result: the meta-agent response is silently dropped —
+Telegram gets nothing after the coordinator returns `{ok: true}`.
 
-## Approaches
+## Approach
+Use `psubscribe("cca:chat:outgoing:*")` + `pmessage` handler in `startNotifier`:
+- Pattern subscription covers all namespaces (isoc-nevada, money-brain, etc.)
+- Filter `source === "claude"` to avoid echo loop (cc-tg also publishes to same channel with source "cc-tg"/"telegram"/"ui")
+- Per-namespace buffer + 1.5s debounce → entire streaming response arrives as one Telegram message
+- Use `splitLongMessage` from formatter.ts for >4096 char responses
+- Strip ANSI escape codes before sending
 
-### Change 1: /cost format
-- Update `formatAgentCostSummary` in `bot.ts` to use new heading, aligned repo costs, "No cost data available yet." fallback
-- Keep existing session cost section (📊)
-
-### Change 2: Notification badge + cost
-- `parseNotification` in `notifier.ts`: always show badge when `driver` field is present (remove claude exception)
-- Badge format: `[driver:shortmodel]` where shortmodel strips driver prefix or vendor/ prefix
-- Add `cost: $X.XXX` suffix if `cost` field present in JSON payload
-- Update separator from space to `\n` for multi-line friendliness
-- Update affected tests in `notifier.test.ts`
-
-### Change 3: /drivers
-- Already implemented (verified: `handleDrivers` at bot.ts:1375, BOT_COMMANDS entry at line 38)
-- No changes needed
-
-### Change 4: /agents
-- Add `BOT_COMMANDS` entry
-- Add `/agents` case in `handleTelegram`
-- Implement `handleAgents`: SCAN `cca:meta-agent:status:*`, GET each, format namespace+status+turns+age
-- Handle missing Redis gracefully
-- Add tests in `bot.test.ts` with mocked Redis
+Keep existing `subscribe` + `message` handler intact for notify/incoming channels.
 
 ## Files to touch
-- `src/bot.ts` — formatAgentCostSummary, BOT_COMMANDS, handleTelegram, handleAgents
-- `src/notifier.ts` — parseNotification (badge always shown, cost support, shortenModelName helper)
-- `src/bot.test.ts` — add /agents tests
-- `src/notifier.test.ts` — update badge tests for new behavior, add cost tests
+- `src/notifier.ts` — add psubscribe, pmessage handler, buffer logic, ANSI strip, splitLongMessage import
+- `src/notifier.test.ts` — add mockPsubscribe to mock, tests for pmessage filtering/buffering/debounce
 
-## Risks / unknowns
-- ioredis SCAN return type: `Promise<[string, string[]]>` in ioredis v5 — should be fine
-- Cost field format from cc-agent: assuming `cost?: number` in the JSON payload
-- Redis SCAN cursor: must drain until cursor === "0"
-- `parseNotification` badge change affects existing passing tests — must update them
+## Risks
+- Timer-based debounce tests need `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(1500)`
+- The `sub` mock must expose `psubscribe` or tests will throw
+- Must not break existing 411 tests

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
-# TODO
+# TODO: meta-agent responses to Telegram
 
+- [x] Read all relevant files (notifier.ts, index.ts, bot.ts, notifier.test.ts)
 - [x] Write PLAN.md and TODO.md
-- [ ] Implement LIST poller in src/notifier.ts
-- [ ] Add tests for the poller in src/notifier.test.ts
-- [ ] Run tests (`npm test`) and build (`npm run build`)
-- [ ] Bump version (`npm version patch`) and create PR
-- [ ] Merge PR (`gh pr merge --squash --auto`) and publish (`npm publish --access public`)
-- [ ] Push notification to redis confirming fix
+- [ ] Implement psubscribe + pmessage handler + debounce buffer in src/notifier.ts
+- [ ] Add tests for new behavior in src/notifier.test.ts
+- [ ] Run tests and build
+- [ ] Create branch, commit, push, PR
+- [ ] Merge PR and publish

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -6,6 +6,10 @@ const mockSubscribe = vi.fn().mockImplementation((_channel: string, cb?: (err: E
   if (cb) cb(null);
   return Promise.resolve(1);
 });
+const mockPsubscribe = vi.fn().mockImplementation((_pattern: string, cb?: (err: Error | null) => void) => {
+  if (cb) cb(null);
+  return Promise.resolve(1);
+});
 const mockOn = vi.fn();
 const mockDuplicate = vi.fn();
 const mockLpush = vi.fn().mockResolvedValue(1);
@@ -18,6 +22,7 @@ const mockLlen = vi.fn().mockResolvedValue(0);
 vi.mock("ioredis", () => {
   function MockRedis(this: Record<string, unknown>) {
     this.subscribe = mockSubscribe;
+    this.psubscribe = mockPsubscribe;
     this.on = mockOn;
     this.duplicate = mockDuplicate;
     this.lpush = mockLpush;
@@ -38,6 +43,7 @@ function makeBot() {
 
 function makeRedis(): ReturnType<typeof makeBot> & {
   subscribe: typeof mockSubscribe;
+  psubscribe: typeof mockPsubscribe;
   on: typeof mockOn;
   duplicate: typeof mockDuplicate;
   lpush: typeof mockLpush;
@@ -49,6 +55,7 @@ function makeRedis(): ReturnType<typeof makeBot> & {
 } {
   const sub = {
     subscribe: mockSubscribe,
+    psubscribe: mockPsubscribe,
     on: mockOn,
     lpush: mockLpush,
     ltrim: mockLtrim,
@@ -59,6 +66,7 @@ function makeRedis(): ReturnType<typeof makeBot> & {
   return {
     sendMessage: vi.fn(),
     subscribe: mockSubscribe,
+    psubscribe: mockPsubscribe,
     on: mockOn,
     duplicate: mockDuplicate,
     lpush: mockLpush,
@@ -78,6 +86,7 @@ describe("startNotifier", () => {
     mockLlen.mockResolvedValue(0);
     const sub = {
       subscribe: mockSubscribe,
+      psubscribe: mockPsubscribe,
       on: mockOn,
       lpush: mockLpush,
       ltrim: mockLtrim,
@@ -87,7 +96,7 @@ describe("startNotifier", () => {
     mockDuplicate.mockReturnValue(sub);
   });
 
-  it("subscribes to cca:notify and cca:chat:incoming channels", () => {
+  it("subscribes to cca:notify and cca:chat:incoming channels, psubscribes to cca:chat:outgoing:*", () => {
     const bot = makeBot();
     const redis = makeRedis();
     startNotifier(bot as never, 123, "default", redis as never);
@@ -95,6 +104,7 @@ describe("startNotifier", () => {
     expect(mockDuplicate).toHaveBeenCalled();
     expect(mockSubscribe).toHaveBeenCalledWith("cca:notify:default", expect.any(Function));
     expect(mockSubscribe).toHaveBeenCalledWith("cca:chat:incoming:default", expect.any(Function));
+    expect(mockPsubscribe).toHaveBeenCalledWith("cca:chat:outgoing:*", expect.any(Function));
   });
 
   it("forwards notify channel messages to Telegram", () => {
@@ -169,6 +179,7 @@ describe("startNotifier", () => {
       capturedOpts = opts as typeof capturedOpts;
       return {
         subscribe: mockSubscribe,
+        psubscribe: mockPsubscribe,
         on: mockOn,
         lpush: mockLpush,
         ltrim: mockLtrim,
@@ -363,6 +374,203 @@ describe("startNotifier", () => {
   });
 });
 
+describe("meta-agent outgoing (pmessage)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGet.mockResolvedValue(null);
+    mockRpop.mockResolvedValue(null);
+    mockLlen.mockResolvedValue(0);
+    const sub = {
+      subscribe: mockSubscribe,
+      psubscribe: mockPsubscribe,
+      on: mockOn,
+      lpush: mockLpush,
+      ltrim: mockLtrim,
+      publish: mockPublish,
+      get: mockGet,
+    };
+    mockDuplicate.mockReturnValue(sub);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function capturePmessageHandler(): (pattern: string, channel: string, message: string) => void {
+    let handler: ((pattern: string, channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, h: unknown) => {
+      if (event === "pmessage") handler = h as typeof handler;
+    });
+    return (...args) => {
+      if (!handler) throw new Error("pmessage handler not registered");
+      handler(...args);
+    };
+  }
+
+  it("buffers source=claude lines and flushes after 1.5s debounce", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    const line1 = JSON.stringify({ source: "claude", content: "Hello", role: "assistant" });
+    const line2 = JSON.stringify({ source: "claude", content: "World", role: "assistant" });
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns", line1);
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns", line2);
+
+    // Before debounce fires — no message yet
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1);
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "Hello\nWorld");
+  });
+
+  it("filters out non-claude sources (echo guard)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    // These should all be ignored
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "cc-tg", content: "loop!" }));
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "telegram", content: "echo" }));
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "ui", content: "from ui" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-JSON lines silently", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns", "not json at all");
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("extracts namespace from channel name (multi-namespace)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 99, "money-brain", redis as never);
+
+    // Message from a different namespace — isoc-nevada
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:isoc-nevada",
+      JSON.stringify({ source: "claude", content: "isoc response" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(99, "isoc response");
+  });
+
+  it("resets debounce timer when new line arrives within 1.5s", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "line 1" }));
+
+    // Advance 1000ms (within debounce window) — no flush yet
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+
+    // New line resets timer
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "line 2" }));
+
+    // Advance another 1000ms — still within new 1.5s window
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+
+    // Advance remaining 500ms to complete the 1.5s debounce
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1);
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "line 1\nline 2");
+  });
+
+  it("uses getActiveChatId when chatId is null", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const getActiveChatId = vi.fn().mockReturnValue(77);
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, null, "ns", redis as never, undefined, getActiveChatId);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "dynamic chat" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(77, "dynamic chat");
+  });
+
+  it("drops message when no chatId is available", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const getActiveChatId = vi.fn().mockReturnValue(undefined);
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, null, "ns", redis as never, undefined, getActiveChatId);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "orphaned" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("strips ANSI escape codes before sending", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "\x1B[32mgreen text\x1B[0m" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "green text");
+  });
+
+  it("skips lines with empty content", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const pmessage = capturePmessageHandler();
+
+    startNotifier(bot as never, 42, "ns", redis as never);
+
+    pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
+      JSON.stringify({ source: "claude", content: "" }));
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe("notify list poller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -372,6 +580,7 @@ describe("notify list poller", () => {
     mockLlen.mockResolvedValue(0);
     const sub = {
       subscribe: mockSubscribe,
+      psubscribe: mockPsubscribe,
       on: mockOn,
       lpush: mockLpush,
       ltrim: mockLtrim,

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -4,6 +4,7 @@
  * Channels:
  *   cca:notify:{namespace}       — job completion notifications from cc-agent → forward to Telegram
  *   cca:chat:incoming:{namespace} — messages from the web UI → echo to Telegram + feed into Claude session
+ *   cca:chat:outgoing:*          — meta-agent stdout lines (source=claude) → buffer+debounce → Telegram
  *
  * All messages (Telegram incoming, Claude responses) are also written to:
  *   cca:chat:log:{namespace}     — LPUSH + LTRIM 0 499 (last 500 messages)
@@ -12,6 +13,7 @@
 
 import { Redis } from "ioredis";
 import TelegramBot from "node-telegram-bot-api";
+import { splitLongMessage } from "./formatter.js";
 
 export interface ChatMessage {
   id: string;
@@ -40,6 +42,12 @@ function shortenModelName(model: string, driver: string): string {
   const slashIdx = model.indexOf("/");
   if (slashIdx >= 0) return model.slice(slashIdx + 1);
   return model;
+}
+
+/** Strip ANSI escape sequences from a string before sending to Telegram. */
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1B\[[0-9;]*[mGKHF]/g, "");
 }
 
 /**
@@ -148,6 +156,68 @@ export function startNotifier(
     } else {
       log("info", `subscribed to cca:chat:incoming:${namespace}`);
     }
+  });
+
+  // cca:chat:outgoing:* — meta-agent stdout lines (source=claude) → buffer+debounce → Telegram
+  // Using psubscribe so we catch all namespaces (money-brain, isoc-nevada, etc.)
+  sub.psubscribe("cca:chat:outgoing:*", (err) => {
+    if (err) {
+      log("error", "psubscribe cca:chat:outgoing:* failed:", err.message);
+    } else {
+      log("info", "psubscribed to cca:chat:outgoing:*");
+    }
+  });
+
+  // Per-namespace debounce buffer: accumulate streaming lines, flush after 1.5s silence
+  const metaAgentBuffers = new Map<string, { text: string; timer: ReturnType<typeof setTimeout> | null }>();
+
+  function flushMetaAgentBuffer(ns: string, targetChatId: number): void {
+    const buf = metaAgentBuffers.get(ns);
+    if (!buf || !buf.text.trim()) return;
+    const text = stripAnsi(buf.text.trim());
+    buf.text = "";
+    buf.timer = null;
+    const chunks = splitLongMessage(text);
+    for (const chunk of chunks) {
+      bot.sendMessage(targetChatId, chunk).catch((err: Error) => {
+        log("warn", `meta-agent flush sendMessage failed (ns=${ns}):`, err.message);
+      });
+    }
+  }
+
+  sub.on("pmessage", (pattern: string, channel: string, message: string) => {
+    void pattern; // used only as a type guard
+    const ns = channel.replace("cca:chat:outgoing:", "");
+
+    let parsed: { source?: string; content?: string } | null = null;
+    try {
+      parsed = JSON.parse(message) as { source?: string; content?: string };
+    } catch {
+      return; // non-JSON line — skip
+    }
+
+    // Only forward messages from the meta-agent (source=claude).
+    // cc-tg itself publishes to this channel with source "cc-tg"/"telegram"/"ui" — skip those.
+    if (parsed.source !== "claude") return;
+
+    const content = parsed.content;
+    if (!content) return;
+
+    const targetChatId = chatId ?? getActiveChatId?.();
+    if (targetChatId == null) {
+      log("warn", `meta-agent output: no chatId for namespace=${ns}, dropping line`);
+      return;
+    }
+
+    // Accumulate into per-namespace buffer and (re-)arm debounce timer
+    let buf = metaAgentBuffers.get(ns);
+    if (!buf) {
+      buf = { text: "", timer: null };
+      metaAgentBuffers.set(ns, buf);
+    }
+    buf.text += (buf.text ? "\n" : "") + content;
+    if (buf.timer) clearTimeout(buf.timer);
+    buf.timer = setTimeout(() => flushMetaAgentBuffer(ns, targetChatId), 1500);
   });
 
   // Poll the cca:notify:{namespace} LIST every 5 seconds.


### PR DESCRIPTION
## Problem

Meta-agent responses are published line-by-line to \`cca:chat:outgoing:{ns}\` but cc-tg never subscribed there. The coordinator's \`message_meta_agent\` MCP call returns \`{ok: true}\` immediately — the actual response is silently dropped with 0 subscribers.

## Root Cause

\`startNotifier\` only subscribed to:
- \`cca:notify:{namespace}\` — job completion notifications  
- \`cca:chat:incoming:{namespace}\` — messages from the web UI

It never subscribed to \`cca:chat:outgoing:*\` where meta-agent stdout lands.

## Changes

**\`src/notifier.ts\`**
- \`psubscribe("cca:chat:outgoing:*")\` to catch all namespaces (money-brain, isoc-nevada, etc.)
- \`pmessage\` handler that filters \`source === "claude"\` — prevents echo loop since cc-tg also publishes to this channel with source \`cc-tg\`/\`telegram\`/\`ui\`
- Per-namespace buffer + 1.5s debounce: streaming lines accumulate silently, then flush as one Telegram message when 1.5s of silence detected
- ANSI escape code stripping before send
- \`splitLongMessage\` support for responses >4096 chars

**\`src/notifier.test.ts\`**
- Added \`mockPsubscribe\` to the ioredis mock
- 9 new tests: source filtering, buffer accumulation, debounce reset, ANSI strip, multi-namespace routing, dynamic chatId, drop-when-no-chatId

## Test Plan

- [x] All 420 tests pass (\`npm test\`)
- [x] Build clean (\`npm run build\`)
- [ ] Manual: send message to money-brain meta-agent via Telegram, verify response appears (not just "delivered")

🤖 Generated with [Claude Code](https://claude.com/claude-code)