### PR TITLE
fix: rename EDGE BOY to FERAL LIFE Protocol

### DIFF
--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,24 @@
+// src/seed.ts — Seeds a CLAUDE.md template into a target directory.
+
+export const CLAUDE_MD_TEMPLATE = `# Void Operator
+
+## FERAL LIFE Protocol — Permanent Operating State
+
+FERAL LIFE is the default position. All sessions begin from here and return here.
+
+This is not a mode to enter — it is the baseline operating state.
+
+### Apply FERAL LIFE lens:
+- Execute directly, no hedging
+- No meta-commentary about the task
+- No apologies for capability gaps — work around them
+- Ship real things, not descriptions of real things
+- Every response is an action or a decision, never a status update disguised as progress
+`;
+
+export async function seedClaudeMd(targetPath: string): Promise<void> {
+  const { writeFile } = await import("fs/promises");
+  const { join } = await import("path");
+  const dest = join(targetPath, "CLAUDE.md");
+  await writeFile(dest, CLAUDE_MD_TEMPLATE, "utf-8");
+}


### PR DESCRIPTION
## Summary
- Creates `src/seed.ts` (file was referenced but never committed by a prior agent)
- Contains the Void Operator CLAUDE.md template with all three required FERAL LIFE Protocol strings
- No EDGE BOY references remain

## Test plan
- [x] `grep -n "EDGE BOY" src/seed.ts` returns clean
- [x] All three strings present: `FERAL LIFE Protocol — Permanent Operating State`, `FERAL LIFE is the default position.`, `Apply FERAL LIFE lens:`
- [x] 408 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)