### PR TITLE
feat: prepend [MM-DD HH:mm] timestamp to user messages sent to Claude

### DIFF
--- a/src/bot.integration.test.ts
+++ b/src/bot.integration.test.ts
@@ -426,7 +426,7 @@ describe('CcTgBot integration — message pipeline', () => {
       await vi.advanceTimersByTimeAsync(65 * 60 * 1000);
 
       // A new Claude session should have been created for the retry
-      expect(mocks.claudeInstance!.sendPrompt).toHaveBeenCalledWith('will hit limit');
+      expect(mocks.claudeInstance!.sendPrompt).toHaveBeenCalledWith(expect.stringMatching(/^\[\d{2}-\d{2} \d{2}:\d{2}\] will hit limit$/));
     } finally {
       Object.assign(process.env, origEnv);
       tokensModule.loadTokens();
@@ -760,7 +760,7 @@ describe('CcTgBot integration — voice message handling', () => {
 
     expect(mocks.tgGetFileLink).toHaveBeenCalledWith('voice-123');
     expect(vi.mocked(transcribeVoice)).toHaveBeenCalledWith('https://example.com/voice.ogg');
-    expect(mocks.claudeInstance!.sendPrompt).toHaveBeenCalledWith('transcribed voice text');
+    expect(mocks.claudeInstance!.sendPrompt).toHaveBeenCalledWith(expect.stringMatching(/^\[\d{2}-\d{2} \d{2}:\d{2}\] transcribed voice text$/));
   });
 
   it('sends error message when transcription returns empty result', async () => {

--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -101,7 +101,7 @@ vi.mock('./notifier.js', () => ({
   writeChatLog: mocks.writeChatLog,
 }));
 
-import { CcTgBot, splitMessage, enrichPromptWithUrls, listSkills } from './bot.js';
+import { CcTgBot, splitMessage, enrichPromptWithUrls, listSkills, stampPrompt } from './bot.js';
 
 function makeMsg(overrides: Record<string, unknown> = {}) {
   return {
@@ -150,6 +150,30 @@ describe('splitMessage', () => {
   it('respects custom maxLen', () => {
     const chunks = splitMessage('hello world', 5);
     expect(chunks).toEqual(['hello', ' worl', 'd']);
+  });
+});
+
+describe('stampPrompt', () => {
+  it('prepends [MM-DD HH:mm] to the text', () => {
+    const now = new Date(2026, 4, 6, 7, 9); // May 6 2026 07:09
+    expect(stampPrompt('hello', now)).toBe('[05-06 07:09] hello');
+  });
+
+  it('zero-pads single-digit month and day', () => {
+    const now = new Date(2026, 0, 3, 8, 5); // Jan 3 2026 08:05
+    expect(stampPrompt('test', now)).toBe('[01-03 08:05] test');
+  });
+
+  it('uses current time when no date provided', () => {
+    const before = new Date();
+    const result = stampPrompt('msg');
+    const after = new Date();
+    // result must start with [MM-DD HH:mm] matching some moment in [before, after]
+    expect(result).toMatch(/^\[\d{2}-\d{2} \d{2}:\d{2}\] msg$/);
+    // The timestamp string can match any minute in [before, after]
+    const mm = String(before.getMonth() + 1).padStart(2, '0');
+    const dd = String(before.getDate()).padStart(2, '0');
+    expect(result).toContain(`[${mm}-${dd}`);
   });
 });
 
@@ -266,7 +290,7 @@ describe('CcTgBot', () => {
 
     it('sends text message to Claude', async () => {
       await sendCommand('Hello Claude');
-      expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('Hello Claude');
+      expect(mocks.claudeSendPrompt).toHaveBeenCalledWith(expect.stringMatching(/^\[\d{2}-\d{2} \d{2}:\d{2}\] Hello Claude$/));
     });
 
     describe('/get_file', () => {
@@ -638,7 +662,7 @@ describe('CcTgBot', () => {
       // (replyToChat with threadId defined)
       // Verify sendMessage was called (session created → startTyping → no reply yet from Claude, but error path won't trigger)
       // At minimum, sendChatAction should have been called
-      expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('Hello');
+      expect(mocks.claudeSendPrompt).toHaveBeenCalledWith(expect.stringMatching(/^\[\d{2}-\d{2} \d{2}:\d{2}\] Hello$/));
     });
 
     it('typing indicator is sent to the correct thread', async () => {
@@ -878,6 +902,38 @@ describe('CcTgBot chat bridge', () => {
       mockRedis,
       'test-ns',
       expect.objectContaining({ role: 'user', source: 'ui', content: 'UI message' })
+    );
+  });
+
+  it('stamps sendPrompt but not writeChatLog for Telegram messages', async () => {
+    const bot = makeBotWithRedis();
+    await (bot as any).handleTelegram(makeMsg({ text: 'stamp me' }));
+    bot.stop();
+
+    // sendPrompt receives the stamped version
+    const promptArg = mocks.claudeSendPrompt.mock.calls[0][0] as string;
+    expect(promptArg).toMatch(/^\[\d{2}-\d{2} \d{2}:\d{2}\] stamp me$/);
+
+    // writeChatLog receives the original text (no timestamp)
+    expect(mocks.writeChatLog).toHaveBeenCalledWith(
+      mockRedis,
+      'test-ns',
+      expect.objectContaining({ content: 'stamp me' })
+    );
+  });
+
+  it('stamps sendPrompt but not writeChatLog for UI messages', async () => {
+    const bot = makeBotWithRedis();
+    await bot.handleUserMessage(42, 'ui stamp me');
+    bot.stop();
+
+    const promptArg = mocks.claudeSendPrompt.mock.calls[0][0] as string;
+    expect(promptArg).toMatch(/^\[\d{2}-\d{2} \d{2}:\d{2}\] ui stamp me$/);
+
+    expect(mocks.writeChatLog).toHaveBeenCalledWith(
+      mockRedis,
+      'test-ns',
+      expect.objectContaining({ content: 'ui stamp me' })
     );
   });
 
@@ -1124,7 +1180,7 @@ describe('handleVoiceRetry', () => {
     bot.stop();
 
     expect(mocks.tgGetFileLink).toHaveBeenCalledWith('voice-abc');
-    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('retried transcript');
+    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith(expect.stringMatching(/^\[\d{2}-\d{2} \d{2}:\d{2}\] retried transcript$/));
     expect(mockRedis.lrem).toHaveBeenCalledWith('voice:pending', 0, entry);
   });
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -100,6 +100,15 @@ function computeCostUsd(usage: UsageEvent): number {
   );
 }
 
+/** Prepend [MM-DD HH:mm] so Claude knows when the message was received. Not shown in Telegram. */
+export function stampPrompt(text: string, now = new Date()): string {
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const hh = String(now.getHours()).padStart(2, "0");
+  const min = String(now.getMinutes()).padStart(2, "0");
+  return `[${mm}-${dd} ${hh}:${min}] ${text}`;
+}
+
 function formatTokens(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
   return String(n);
@@ -498,7 +507,7 @@ export class CcTgBot {
       const enriched = await enrichPromptWithUrls(text);
       const prompt = buildPromptWithReplyContext(enriched, msg);
       session.currentPrompt = prompt;
-      session.claude.sendPrompt(prompt);
+      session.claude.sendPrompt(stampPrompt(prompt));
       this.startTyping(chatId, session);
       this.writeChatMessage("user", "telegram", text, chatId);
     } catch (err) {
@@ -516,7 +525,7 @@ export class CcTgBot {
     try {
       const enriched = await enrichPromptWithUrls(text);
       session.currentPrompt = enriched;
-      session.claude.sendPrompt(enriched);
+      session.claude.sendPrompt(stampPrompt(enriched));
       this.startTyping(chatId, session);
       this.writeChatMessage("user", "ui", text, chatId);
     } catch (err) {
@@ -568,7 +577,7 @@ export class CcTgBot {
         const prompt = buildPromptWithReplyContext(transcript, msg);
         this.writeChatMessage("user", "telegram", transcript, chatId);
         session.currentPrompt = prompt;
-        session.claude.sendPrompt(prompt);
+        session.claude.sendPrompt(stampPrompt(prompt));
         this.startTyping(chatId, session);
       } catch (err) {
         await this.replyToChat(chatId, `Error sending to Claude: ${(err as Error).message}`, threadId);
@@ -648,7 +657,7 @@ export class CcTgBot {
 
         if (transcript && transcript !== "[empty transcription]") {
           const session = this.getOrCreateSession(entry.chat_id, threadId, undefined);
-          session.claude.sendPrompt(transcript);
+          session.claude.sendPrompt(stampPrompt(transcript));
           this.writeChatMessage("user", "telegram", transcript, entry.chat_id);
 
           // Remove from both lists
@@ -706,7 +715,7 @@ export class CcTgBot {
       const imageData = await fetchAsBase64(fileLink);
       // Telegram photos are always JPEG
       const session = this.getOrCreateSession(chatId, threadId, threadName);
-      session.claude.sendImage(imageData, "image/jpeg", caption);
+      session.claude.sendImage(imageData, "image/jpeg", stampPrompt(caption ?? ""));
       this.startTyping(chatId, session);
     } catch (err) {
       console.error(`[photo:${chatId}] error:`, (err as Error).message);
@@ -737,7 +746,7 @@ export class CcTgBot {
         : `ATTACHMENTS: [${fileName}](${destPath})`;
 
       const session = this.getOrCreateSession(chatId, threadId, threadName);
-      session.claude.sendPrompt(prompt);
+      session.claude.sendPrompt(stampPrompt(prompt));
       this.startTyping(chatId, session);
     } catch (err) {
       console.error(`[doc:${chatId}] error:`, (err as Error).message);
@@ -875,7 +884,7 @@ export class CcTgBot {
           const retrySession = this.getOrCreateSession(chatId, threadId);
           retrySession.currentPrompt = lastPrompt;
           retrySession.isRetry = true;
-          retrySession.claude.sendPrompt(lastPrompt);
+          retrySession.claude.sendPrompt(stampPrompt(lastPrompt));
           this.startTyping(chatId, retrySession);
         } catch (err) {
           this.replyToChat(chatId, `❌ Failed to retry with rotated token: ${(err as Error).message}`, threadId).catch(() => {});
@@ -896,7 +905,7 @@ export class CcTgBot {
           const retrySession = this.getOrCreateSession(chatId, threadId);
           retrySession.currentPrompt = lastPrompt;
           retrySession.isRetry = true;
-          retrySession.claude.sendPrompt(lastPrompt);
+          retrySession.claude.sendPrompt(stampPrompt(lastPrompt));
           this.startTyping(chatId, retrySession);
         } catch (err) {
           this.replyToChat(chatId, `❌ Failed to retry: ${(err as Error).message}`, threadId).catch(() => {});


### PR DESCRIPTION
## Summary
- Adds `stampPrompt(text)` helper that prepends `[MM-DD HH:mm]` to every user message before it reaches Claude
- Applied at all `sendPrompt`/`sendImage` call sites: Telegram text, UI messages, voice transcripts, documents, and token-rotation retries
- Cron tasks intentionally excluded — they are scheduled prompts, not live user messages
- `writeChatMessage` still receives original text so timestamp never appears in Telegram

## Test plan
- [x] New `stampPrompt` unit tests verify format, zero-padding, and default-time behavior
- [x] Two new integration assertions confirm `sendPrompt` gets stamped text while `writeChatLog` gets original
- [x] Five existing tests updated to use `stringMatching` for the timestamp prefix
- [x] All 417 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)