### PR TITLE
fix: correct npm cache path in clear_npx_cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.30",
+      "version": "0.9.31",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- `handleClearNpxCache` was using `npm_config_cache` parent directory (going one level up with `..`) as `npmBase`, incorrectly targeting non-existent paths
- Fix: use `npm_config_cache` env var directly as the base, so `/clear_npx_cache` correctly targets `${npm_config_cache}/_npx` and `${npm_config_cache}` itself
- Bump to 0.9.31

## Test plan
- [x] All 417 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)