### PR TITLE
Feed job completion notifications into Claude session

### DIFF
--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -708,6 +708,42 @@ describe("notify list poller", () => {
     expect(bot.sendMessage).toHaveBeenCalledWith(42, "dynamic notify");
   });
 
+  it("calls handleUserMessage for each polled notify item", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "Task complete" }))
+      .mockResolvedValueOnce(JSON.stringify({ text: "Another job done" }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 555, "ns-hum", redis as never, handleUserMessage);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "Task complete");
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "Another job done");
+    expect(handleUserMessage).toHaveBeenCalledWith(555, "Task complete");
+    expect(handleUserMessage).toHaveBeenCalledWith(555, "Another job done");
+    expect(handleUserMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not call handleUserMessage when it is undefined (poll path)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "Silent notify" }))
+      .mockResolvedValue(null);
+
+    // No handleUserMessage — should not throw
+    startNotifier(bot as never, 555, "ns-nohum", redis as never);
+
+    await expect(vi.advanceTimersByTimeAsync(5_000)).resolves.not.toThrow();
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "Silent notify");
+  });
+
   it("continues gracefully when rpop throws", async () => {
     const bot = makeBot();
     const redis = makeRedis();
@@ -790,6 +826,43 @@ describe("parseNotification", () => {
 
   it("returns raw string when JSON has no text field", () => {
     expect(parseNotification(JSON.stringify({ foo: "bar" }))).toBe(JSON.stringify({ foo: "bar" }));
+  });
+
+  it("pub/sub handler calls handleUserMessage with same text sent to Telegram", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 456, "myns", redis as never, handleUserMessage);
+
+    messageHandler!("cca:notify:myns", "Job done: my-task");
+    expect(bot.sendMessage).toHaveBeenCalledWith(456, "Job done: my-task");
+    expect(handleUserMessage).toHaveBeenCalledWith(456, "Job done: my-task");
+  });
+
+  it("pub/sub handler does not call handleUserMessage when it is undefined", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    // No handleUserMessage passed — should not throw
+    startNotifier(bot as never, 456, "myns", redis as never);
+
+    expect(() => messageHandler!("cca:notify:myns", "Job done")).not.toThrow();
+    expect(bot.sendMessage).toHaveBeenCalledWith(456, "Job done");
   });
 
   it("pub/sub handler uses parseNotification — JSON badge appears in sent message", () => {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -257,6 +257,9 @@ export function startNotifier(
       bot.sendMessage(targetId, text).catch((err: Error) => {
         log("warn", "notify list sendMessage failed:", err.message);
       });
+      if (handleUserMessage) {
+        handleUserMessage(targetId, text);
+      }
     }
 
     if (remaining > 0) {
@@ -281,6 +284,9 @@ export function startNotifier(
         bot.sendMessage(targetId, text).catch((err: Error) => {
           log("warn", "sendMessage failed:", err.message);
         });
+        if (handleUserMessage) {
+          handleUserMessage(targetId, text);
+        }
       } else {
         log("warn", "notify: no chatId available, dropping notification");
       }


### PR DESCRIPTION
## Summary
- When a cc-agent job completes, the notification now goes to both Telegram AND the active Claude Code coordinator session via `handleUserMessage`
- Two call sites patched: pub/sub `cca:notify:{namespace}` message handler and `pollNotifyList` loop
- Enables autonomous follow-up by the coordinator without waiting for user relay

## Test plan
- [x] Two new tests for pub/sub notify handler: confirms `handleUserMessage` called with same `targetId`+`text`, and confirms no-throw when `handleUserMessage` is undefined
- [x] Two new tests for `pollNotifyList`: confirms `handleUserMessage` called once per drained item, and confirms no-throw when undefined
- [x] All 421 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)