### PR TITLE
feat: hashtag meta-agent routing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,35 +1,51 @@
-# Protocol Compliance Audit — Plan
+# Plan: Hashtag Meta-Agent Routing
 
-## Task Summary
-Audit cc-tg source against the cc-suite Redis communication protocol and fix every deviation.
-Protocol doc URL returned 404 so working from task spec directly.
+## Task restatement
 
-## Deviations Found
+When a Telegram user sends a message containing `#tag` or `#org/repo`, route it to the
+corresponding cc-agent meta-agent instead of the local Claude session. Auto-create the
+GitHub repo and start the meta-agent if not already running. Reply immediately with
+`→ #namespace` so the user knows the message was delegated.
 
-| # | File | Location | Issue | Fix |
-|---|------|----------|-------|-----|
-| 1 | bot.ts | :273 | `id` uses timestamp+random, not UUID | `crypto.randomUUID()` |
-| 2 | notifier.ts | :318 | `id` uses timestamp+random, not UUID | `crypto.randomUUID()` |
-| 3 | notifier.ts | :98 | LPUSH has no ordering comment | Add "LIFO — newest first" comment |
-| 4 | notifier.ts | :341 | `lpush` to meta-agent input (should be `rpush`) + no timing comment | `rpush` + add latency comment |
-| 5 | bot.ts | :74 | `FLUSH_DELAY_MS` has no descriptive comment | Add behavior comment |
-| 6 | notifier.ts | :220 | 1500ms debounce is a magic number | Extract to `META_AGENT_FLUSH_DELAY_MS` constant + add comment |
-| 7 | tokens.ts | — | No comment about independent rotation from cc-agent pool | Add comment |
-| 8 | docs/ | — | Protocol markdown missing | Create docs/redis-protocol.md |
+## Approach options
 
-## No Deviations (already correct)
-- `writeChatLog()` does dual-write (LPUSH + PUBLISH) ✓
-- `parseNotification()` handles both JSON and plain-string fallback ✓
-- `source` values match spec: 'telegram' | 'ui' | 'claude' | 'cc-tg' ✓
-- `role` values match spec: 'user' | 'assistant' | 'tool' ✓
-- ChatMessage shape has id, source, role, content, timestamp, chatId ✓
+### A. Redis-only approach
+Skip MCP tools entirely. Check `cca:meta-agent:status:{namespace}` directly, use `spawn_agent`
+MCP tool to start, RPUSH to `cca:meta:{namespace}:input` to send.
+- Pro: Known working tools, consistent with notifier.ts patterns
+- Con: `spawn_agent` requires a `task` string — unclear what task makes a "meta-agent"
 
-## Approach
-Direct edits to the 3 source files + new docs/redis-protocol.md.
-No architectural changes needed.
+### B. MCP tool approach (spec-faithful)
+Call `start_meta_agent` and `message_meta_agent` via `callCcAgentTool`, check status via Redis.
+- Pro: Follows task spec, clean separation of concerns
+- Con: These tools may not exist in current cc-agent, returns null on failure
 
-## Files to Touch
-- src/bot.ts
-- src/notifier.ts
-- src/tokens.ts
-- docs/redis-protocol.md (new)
+### C. Hybrid (chosen)
+- Check Redis for `cca:meta-agent:status:{namespace}` directly (known-working pattern from notifier.ts)
+- Call `callCcAgentTool("start_meta_agent", {namespace, repo_url})` to start — throw on null
+- Route messages via Redis RPUSH to `cca:meta:{namespace}:input` (known-working pattern)
+- Use `execSync` for `gh` repo verification/creation (same pattern as bot.ts)
+
+**Why this:** Stays consistent with existing code patterns, is spec-faithful for the start mechanism,
+and uses the reliable Redis RPUSH that notifier.ts already does for routing.
+
+## Files to touch
+
+- `src/router.ts` — new: parseRoutingTag, ensureMetaAgent, routeToMetaAgent
+- `src/router.test.ts` — new: unit tests
+- `src/bot.ts` — add routing check in handleTelegram() before getOrCreateSession()
+
+## Risks
+
+- `start_meta_agent` MCP tool may not exist → error surfaced to user with clear message
+- `gh` CLI may not be installed in the runtime environment → execSync throws, caught and re-thrown
+- strippedMessage may be empty if user sends only `#tag` → routeToMetaAgent is skipped, ensureMetaAgent still runs
+- Regex `#org/repo` might greedily match inside URLs → acceptable; Telegram plain text rarely embeds bare URLs with hash routing syntax
+
+## Key decisions
+
+- Tag parsed anywhere in message (not just start), first match wins
+- Strip tag + normalize whitespace before forwarding
+- If Redis not configured, skip routing entirely (fall through to local Claude)
+- Route BEFORE getOrCreateSession (skips local Claude session entirely)
+- Log the user message to chat log as "user"/"telegram" before routing

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -18,6 +18,7 @@ import { detectUsageLimit } from "./usage-limit.js";
 import { getCurrentToken, rotateToken, getTokenIndex, getTokenCount } from "./tokens.js";
 import { writeChatLog, type ChatMessage } from "./notifier.js";
 import { CronManager } from "./cron.js";
+import { parseRoutingTag, ensureMetaAgent, routeToMetaAgent } from "./router.js";
 
 const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "start", description: "Reset session and start fresh" },
@@ -501,6 +502,32 @@ export class CcTgBot {
     if (text === "/agents") {
       await this.handleAgents(chatId, threadId);
       return;
+    }
+
+    // #tag / #org/repo routing — delegate to meta-agent instead of local Claude session
+    if (this.redis) {
+      const routing = parseRoutingTag(text);
+      if (routing) {
+        // Acknowledge routing immediately so user knows the message was delegated
+        await this.replyToChat(chatId, `→ #${routing.namespace}`, threadId);
+        this.writeChatMessage("user", "telegram", text, chatId);
+        try {
+          await ensureMetaAgent(
+            routing.namespace,
+            routing.repoUrl,
+            (toolName, args) => this.callCcAgentTool(toolName, args ?? {}),
+            this.redis
+          );
+          await routeToMetaAgent(routing.namespace, routing.strippedMessage, this.redis);
+        } catch (err) {
+          await this.replyToChat(
+            chatId,
+            `Failed to route to #${routing.namespace}: ${(err as Error).message}`,
+            threadId
+          );
+        }
+        return;
+      }
     }
 
     const session = this.getOrCreateSession(chatId, threadId, threadName);

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseRoutingTag, ensureMetaAgent, routeToMetaAgent } from "./router.js";
+
+// ---- child_process mock ----
+const mockExecSync = vi.fn();
+vi.mock("child_process", () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// ---- ioredis mock ----
+const mockGet = vi.fn();
+const mockRpush = vi.fn().mockResolvedValue(1);
+
+function makeRedis() {
+  return { get: mockGet, rpush: mockRpush } as unknown as import("ioredis").Redis;
+}
+
+// ---- helpers ----
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.DEFAULT_GITHUB_ORG;
+  delete process.env.META_AGENT_TIMEOUT_MS;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ===========================================================================
+// parseRoutingTag
+// ===========================================================================
+
+describe("parseRoutingTag", () => {
+  it("returns null when no # tag present", () => {
+    expect(parseRoutingTag("hello world")).toBeNull();
+    expect(parseRoutingTag("fix the bug please")).toBeNull();
+  });
+
+  it("parses simple #repo-name at start", () => {
+    const result = parseRoutingTag("#cc-agent fix the bug");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("cc-agent");
+    expect(result!.repoUrl).toBe("https://github.com/gonzih/cc-agent");
+    expect(result!.strippedMessage).toBe("fix the bug");
+  });
+
+  it("parses #repo-name anywhere in message", () => {
+    const result = parseRoutingTag("please help with #of-stack this issue");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("of-stack");
+    expect(result!.strippedMessage).toBe("please help with this issue");
+  });
+
+  it("parses #org/repo format", () => {
+    const result = parseRoutingTag("#gonzih/of-stack deploy it");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("of-stack");
+    expect(result!.repoUrl).toBe("https://github.com/gonzih/of-stack");
+    expect(result!.strippedMessage).toBe("deploy it");
+  });
+
+  it("parses #org/repo with different org", () => {
+    const result = parseRoutingTag("#myorg/myrepo do something");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("myrepo");
+    expect(result!.repoUrl).toBe("https://github.com/myorg/myrepo");
+  });
+
+  it("uses DEFAULT_GITHUB_ORG env var when set", () => {
+    process.env.DEFAULT_GITHUB_ORG = "mycompany";
+    const result = parseRoutingTag("#my-service do stuff");
+    expect(result).not.toBeNull();
+    expect(result!.repoUrl).toBe("https://github.com/mycompany/my-service");
+  });
+
+  it("strips only the tag token, preserves rest of message", () => {
+    const result = parseRoutingTag("#cc-agent");
+    expect(result).not.toBeNull();
+    expect(result!.strippedMessage).toBe("");
+  });
+
+  it("collapses extra whitespace after strip", () => {
+    const result = parseRoutingTag("fix  #cc-agent  the bug");
+    expect(result).not.toBeNull();
+    expect(result!.strippedMessage).toBe("fix the bug");
+  });
+
+  it("uses first match only when multiple tags present", () => {
+    const result = parseRoutingTag("#repo-a do stuff #repo-b");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("repo-a");
+  });
+
+  it("handles underscores and dots in repo name", () => {
+    const result = parseRoutingTag("#my_repo.v2 task");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("my_repo.v2");
+  });
+
+  it("returns null for bare # with no following word char", () => {
+    expect(parseRoutingTag("hello # world")).toBeNull();
+  });
+});
+
+// ===========================================================================
+// routeToMetaAgent
+// ===========================================================================
+
+describe("routeToMetaAgent", () => {
+  it("RPUSHes a JSON entry to cca:meta:{namespace}:input", async () => {
+    mockRpush.mockResolvedValue(1);
+    const redis = makeRedis();
+
+    await routeToMetaAgent("cc-agent", "fix the bug", redis);
+
+    expect(mockRpush).toHaveBeenCalledOnce();
+    const [key, rawEntry] = mockRpush.mock.calls[0] as [string, string];
+    expect(key).toBe("cca:meta:cc-agent:input");
+
+    const entry = JSON.parse(rawEntry) as { id: string; content: string; timestamp: string };
+    expect(entry.content).toBe("fix the bug");
+    expect(entry.id).toMatch(/^[0-9a-f-]{36}$/); // UUID format
+    expect(entry.timestamp).toBeTruthy();
+  });
+
+  it("is a no-op when strippedMessage is empty", async () => {
+    const redis = makeRedis();
+    await routeToMetaAgent("cc-agent", "", redis);
+    expect(mockRpush).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// ensureMetaAgent
+// ===========================================================================
+
+describe("ensureMetaAgent", () => {
+  it("returns early when meta-agent is already running", async () => {
+    mockGet.mockResolvedValue(JSON.stringify({ status: "running" }));
+    const callTool = vi.fn();
+    const redis = makeRedis();
+
+    await ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis);
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("starts meta-agent when not running (repo already exists)", async () => {
+    // Not running initially
+    mockGet.mockResolvedValueOnce(null);
+    // Poll: not running on first tick, running on second
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "running" }));
+
+    // gh repo view succeeds (repo exists)
+    mockExecSync.mockReturnValue("");
+
+    const callTool = vi.fn().mockResolvedValue('{"started":true}');
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis);
+
+    // Advance through poll ticks
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(callTool).toHaveBeenCalledWith("start_meta_agent", {
+      namespace: "cc-agent",
+      repo_url: "https://github.com/gonzih/cc-agent",
+    });
+    // gh repo view called with correct orgRepo
+    expect(mockExecSync).toHaveBeenCalledWith("gh repo view gonzih/cc-agent", { stdio: "ignore" });
+  });
+
+  it("creates repo when gh repo view fails, then starts meta-agent", async () => {
+    mockGet.mockResolvedValueOnce(null);
+    mockGet.mockResolvedValue(JSON.stringify({ status: "running" }));
+
+    // gh repo view throws (not found), gh repo create succeeds
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error("not found"); })
+      .mockReturnValue("");
+
+    const callTool = vi.fn().mockResolvedValue("ok");
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("my-ns", "https://github.com/gonzih/my-ns", callTool, redis);
+    await vi.advanceTimersByTimeAsync(1500);
+    await promise;
+
+    expect(mockExecSync).toHaveBeenNthCalledWith(1, "gh repo view gonzih/my-ns", { stdio: "ignore" });
+    expect(mockExecSync).toHaveBeenNthCalledWith(
+      2,
+      `gh repo create gonzih/my-ns --public --description "Meta-agent workspace for my-ns"`,
+      { stdio: "pipe" }
+    );
+  });
+
+  it("throws when start_meta_agent tool returns null", async () => {
+    mockGet.mockResolvedValue(null);
+    mockExecSync.mockReturnValue(""); // repo exists
+
+    const callTool = vi.fn().mockResolvedValue(null);
+    const redis = makeRedis();
+
+    await expect(
+      ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis)
+    ).rejects.toThrow("start_meta_agent returned null");
+  });
+
+  it("throws on timeout when meta-agent never becomes ready", async () => {
+    mockGet.mockResolvedValue(null); // never becomes running
+    mockExecSync.mockReturnValue("");
+
+    const callTool = vi.fn().mockResolvedValue("ok");
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "3000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis);
+    // Attach rejection handler immediately to prevent unhandled rejection warning
+    const caught = promise.catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(5000);
+    const err = await caught;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("did not become ready within 3000ms");
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,160 @@
+/**
+ * Hashtag meta-agent routing.
+ *
+ * Parses #tag or #org/repo tokens from Telegram messages and routes them to
+ * the appropriate cc-agent meta-agent instead of the local Claude session.
+ *
+ * Tag formats:
+ *   #repo-name    → namespace=repo-name, repo=https://github.com/{DEFAULT_GITHUB_ORG}/repo-name
+ *   #org/repo     → namespace=repo,      repo=https://github.com/org/repo
+ */
+
+import { execSync } from "child_process";
+import { Redis } from "ioredis";
+
+/** Callback type matching CcTgBot.callCcAgentTool */
+export type CallToolFn = (toolName: string, args?: Record<string, unknown>) => Promise<string | null>;
+
+export interface RoutingTag {
+  namespace: string;
+  repoUrl: string;
+  /** Original message with the tag token stripped and whitespace collapsed */
+  strippedMessage: string;
+}
+
+/**
+ * Parse the first #tag or #org/repo token from a message.
+ * Returns null when no routing tag is present.
+ *
+ * Examples:
+ *   "#cc-agent fix the bug"           → { namespace: "cc-agent", repoUrl: "…/gonzih/cc-agent", … }
+ *   "#gonzih/of-stack deploy it"      → { namespace: "of-stack", repoUrl: "…/gonzih/of-stack", … }
+ *   "#org/repo do something"          → { namespace: "repo",     repoUrl: "…/org/repo", … }
+ *   "please help #of-stack with this" → { namespace: "of-stack", repoUrl: "…/gonzih/of-stack", … }
+ */
+export function parseRoutingTag(text: string): RoutingTag | null {
+  const defaultOrg = process.env.DEFAULT_GITHUB_ORG ?? "gonzih";
+
+  // Match #word or #org/repo — each segment: starts with alphanumeric, allows ._- inside
+  const match = text.match(/#([a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\/([a-zA-Z0-9][a-zA-Z0-9._-]*))?/);
+  if (!match) return null;
+
+  const fullMatch = match[0]; // e.g. "#gonzih/of-stack"
+  const part1 = match[1];    // org-or-repo
+  const part2 = match[2];    // repo (only present in #org/repo format)
+
+  let namespace: string;
+  let repoUrl: string;
+
+  if (part2) {
+    // #org/repo format
+    namespace = part2;
+    repoUrl = `https://github.com/${part1}/${part2}`;
+  } else {
+    // #repo format — use DEFAULT_GITHUB_ORG
+    namespace = part1;
+    repoUrl = `https://github.com/${defaultOrg}/${part1}`;
+  }
+
+  // Strip the matched tag token and collapse whitespace
+  const strippedMessage = text.replace(fullMatch, "").replace(/\s+/g, " ").trim();
+
+  return { namespace, repoUrl, strippedMessage };
+}
+
+/**
+ * Ensure a meta-agent for the given namespace is running.
+ *
+ * Steps:
+ *   1. Check cca:meta-agent:status:{namespace} in Redis — return early if already running.
+ *   2. Verify the GitHub repo exists; create it (public) if not.
+ *   3. Call the start_meta_agent MCP tool via callTool.
+ *   4. Poll the Redis status key every 1s until running or META_AGENT_TIMEOUT_MS expires.
+ *
+ * Throws on failure (repo creation error, tool call failure, or timeout).
+ */
+export async function ensureMetaAgent(
+  namespace: string,
+  repoUrl: string,
+  callTool: CallToolFn,
+  redis: Redis
+): Promise<void> {
+  const timeoutMs = parseInt(process.env.META_AGENT_TIMEOUT_MS ?? "10000", 10);
+  const statusKey = `cca:meta-agent:status:${namespace}`;
+
+  // Fast path: already running
+  const statusRaw = await redis.get(statusKey);
+  if (statusRaw) {
+    try {
+      const status = JSON.parse(statusRaw) as { status?: string };
+      if (status.status === "running") return;
+    } catch {
+      // Corrupt status value — fall through and restart
+    }
+  }
+
+  // Derive "org/repo" from the full URL for gh CLI calls
+  const orgRepo = repoUrl.replace(/^https:\/\/github\.com\//, "");
+
+  // Verify / create the GitHub repo
+  try {
+    execSync(`gh repo view ${orgRepo}`, { stdio: "ignore" });
+  } catch {
+    // Repo not found — create it
+    try {
+      execSync(
+        `gh repo create ${orgRepo} --public --description "Meta-agent workspace for ${namespace}"`,
+        { stdio: "pipe" }
+      );
+      console.log(`[router] created repo ${orgRepo} for namespace=${namespace}`);
+    } catch (createErr) {
+      throw new Error(`Failed to create repo ${orgRepo}: ${(createErr as Error).message}`);
+    }
+  }
+
+  // Start the meta-agent via MCP
+  const result = await callTool("start_meta_agent", { namespace, repo_url: repoUrl });
+  if (result === null) {
+    throw new Error(`start_meta_agent returned null — tool may not be available in cc-agent`);
+  }
+
+  // Poll until the meta-agent reports "running"
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+    const raw = await redis.get(statusKey);
+    if (raw) {
+      try {
+        const s = JSON.parse(raw) as { status?: string };
+        if (s.status === "running") return;
+      } catch {
+        // ignore parse errors, keep polling
+      }
+    }
+  }
+
+  throw new Error(`Meta-agent for ${namespace} did not become ready within ${timeoutMs}ms`);
+}
+
+/**
+ * Route a message to a running meta-agent via Redis RPUSH.
+ * The cc-agent polls cca:meta:{namespace}:input every 3s (up to 3s delivery latency).
+ *
+ * No-op when strippedMessage is empty (user sent only the tag token).
+ */
+export async function routeToMetaAgent(
+  namespace: string,
+  strippedMessage: string,
+  redis: Redis
+): Promise<void> {
+  if (!strippedMessage) return;
+
+  const entry = JSON.stringify({
+    id: crypto.randomUUID(),
+    content: strippedMessage,
+    timestamp: new Date().toISOString(),
+  });
+  // FIFO — cc-agent reads via LPOP
+  await redis.rpush(`cca:meta:${namespace}:input`, entry);
+  console.log(`[router] routed message to meta-agent namespace=${namespace}`);
+}


### PR DESCRIPTION
## Summary

- Adds `#tag` / `#org/repo` routing in Telegram messages: messages are delegated to the corresponding cc-agent meta-agent instead of spawning a local Claude session
- New `src/router.ts` with `parseRoutingTag`, `ensureMetaAgent`, `routeToMetaAgent` — all independently testable
- Routing ack reply (`→ #namespace`) sent immediately so user knows the message was delegated
- Auto-creates GitHub repo and starts meta-agent if not already running, polls Redis until ready (up to `META_AGENT_TIMEOUT_MS`, default 10s)
- Falls through to normal local Claude session when Redis is not configured or no tag is found

## Routing formats

| Input | Namespace | Repo URL |
|-------|-----------|---------|
| `#cc-agent fix bug` | `cc-agent` | `github.com/gonzih/cc-agent` |
| `#gonzih/of-stack deploy` | `of-stack` | `github.com/gonzih/of-stack` |
| `#org/repo task` | `repo` | `github.com/org/repo` |

## New env vars

- `DEFAULT_GITHUB_ORG` — org to use for `#repo` tags without explicit org (default: `gonzih`)
- `META_AGENT_TIMEOUT_MS` — how long to poll for meta-agent ready state (default: `10000`)

## Test plan

- [x] `parseRoutingTag` unit tests: all tag formats, edge cases, whitespace normalization
- [x] `routeToMetaAgent` unit tests: RPUSH payload format, no-op on empty message
- [x] `ensureMetaAgent` unit tests: fast-path (already running), start flow, repo creation, timeout, null tool failure
- [x] All 439 existing tests continue to pass
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)