### PR TITLE
feat: forum topic meta-agent routing

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -235,6 +235,8 @@ export class CcTgBot {
   private namespace: string;
   private lastActiveChatId?: number;
   private cron: CronManager;
+  /** In-memory cache of forum topic names: `${chatId}:${threadId}` → topic name */
+  private topicNameCache = new Map<string, string>();
 
   constructor(opts: BotOptions) {
     this.opts = opts;
@@ -319,6 +321,19 @@ export class CcTgBot {
     }
   }
 
+  /**
+   * Parse FORUM_META_AGENT_ROUTING env var.
+   *   "auto" (default) → route all forum topics to meta-agents
+   *   "off"            → disable forum routing entirely
+   *   "topic-a,topic-b" → only route these named topics
+   */
+  private getForumRoutingConfig(): "auto" | "off" | Set<string> {
+    const raw = process.env.FORUM_META_AGENT_ROUTING;
+    if (!raw || raw === "auto") return "auto";
+    if (raw === "off") return "off";
+    return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+  }
+
   private isAllowed(userId: number): boolean {
     if (!this.opts.allowedUserIds?.length) return true;
     return this.opts.allowedUserIds.includes(userId);
@@ -335,6 +350,27 @@ export class CcTgBot {
     const threadName = rawMsg.forum_topic_created
       ? (rawMsg.forum_topic_created as Record<string, unknown>).name as string | undefined
       : undefined;
+
+    // Cache forum topic names from service messages so routing can look them up later
+    if (threadId !== undefined) {
+      if (threadName) {
+        this.topicNameCache.set(`${chatId}:${threadId}`, threadName);
+      }
+      // forum_topic_edited carries name only when the name was changed
+      const editedTopicName = (rawMsg.forum_topic_edited as Record<string, unknown> | undefined)?.name as string | undefined;
+      if (editedTopicName) {
+        this.topicNameCache.set(`${chatId}:${threadId}`, editedTopicName);
+      }
+      // Best-effort: first message in a topic often has reply_to_message pointing to the creation event
+      if (!this.topicNameCache.has(`${chatId}:${threadId}`)) {
+        const replyRaw = msg.reply_to_message as unknown as Record<string, unknown> | undefined;
+        const replyCreated = replyRaw?.forum_topic_created as Record<string, unknown> | undefined;
+        const replyName = replyCreated?.name as string | undefined;
+        if (replyName) {
+          this.topicNameCache.set(`${chatId}:${threadId}`, replyName);
+        }
+      }
+    }
 
     if (!this.isAllowed(userId)) {
       await this.replyToChat(chatId, "Not authorized.", threadId);
@@ -527,6 +563,41 @@ export class CcTgBot {
           );
         }
         return;
+      }
+    }
+
+    // Forum topic → meta-agent routing (runs after hashtag routing so explicit #tag wins)
+    if (this.redis && threadId !== undefined) {
+      const topicKey = `${chatId}:${threadId}`;
+      const topicName = this.topicNameCache.get(topicKey);
+      if (topicName) {
+        const namespace = normalizeTopicNamespace(topicName);
+        const routingConfig = this.getForumRoutingConfig();
+        const shouldRoute =
+          routingConfig === "auto" ||
+          (routingConfig instanceof Set && (routingConfig.has(topicName) || routingConfig.has(namespace)));
+        if (shouldRoute) {
+          const defaultOrg = process.env.DEFAULT_GITHUB_ORG ?? "gonzih";
+          const repoUrl = `https://github.com/${defaultOrg}/${namespace}`;
+          await this.replyToChat(chatId, `→ #${namespace} (meta-agent)`, threadId);
+          this.writeChatMessage("user", "telegram", text, chatId);
+          try {
+            await ensureMetaAgent(
+              namespace,
+              repoUrl,
+              (toolName, args) => this.callCcAgentTool(toolName, args ?? {}),
+              this.redis
+            );
+            await routeToMetaAgent(namespace, text, this.redis);
+          } catch (err) {
+            await this.replyToChat(
+              chatId,
+              `Failed to route to #${namespace}: ${(err as Error).message}`,
+              threadId
+            );
+          }
+          return;
+        }
       }
     }
 
@@ -1722,6 +1793,26 @@ export function listSkills(): string {
     }
   }
   return lines.join("\n");
+}
+
+/**
+ * Normalize a Telegram forum topic name into a meta-agent namespace.
+ * Rules: strip leading #, lowercase, spaces → hyphens, non-alphanumeric → hyphens,
+ * collapse and trim hyphens.
+ *
+ * Examples:
+ *   "CC Suite"  → "cc-suite"
+ *   "#research" → "research"
+ *   "of-stack"  → "of-stack"
+ */
+export function normalizeTopicNamespace(name: string): string {
+  return name
+    .replace(/^#+/, "")              // strip leading # prefix
+    .toLowerCase()
+    .replace(/\s+/g, "-")           // spaces → hyphens
+    .replace(/[^a-z0-9._-]/g, "-")  // non-alphanumeric/non-safe → hyphens
+    .replace(/-+/g, "-")            // collapse consecutive hyphens
+    .replace(/^-|-$/g, "");         // trim leading/trailing hyphens
 }
 
 export function splitMessage(text: string, maxLen = 4096): string[] {

--- a/src/forum-routing.test.ts
+++ b/src/forum-routing.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---- hoisted mocks (must come before imports) ----
+const mocks = vi.hoisted(() => ({
+  tgSendMessage: vi.fn().mockResolvedValue({}),
+  tgSendChatAction: vi.fn().mockResolvedValue({}),
+  tgSetMyCommands: vi.fn().mockResolvedValue({}),
+  tgOn: vi.fn(),
+  tgStopPolling: vi.fn(),
+  tgGetMe: vi.fn().mockResolvedValue({ id: 999, username: "testbot" }),
+  claudeOn: vi.fn(),
+  claudeSendPrompt: vi.fn(),
+  claudeKill: vi.fn(),
+  cronList: vi.fn().mockReturnValue([]),
+  cronAdd: vi.fn().mockReturnValue(null),
+  cronRemove: vi.fn().mockReturnValue(false),
+  cronClearAll: vi.fn().mockReturnValue(0),
+  cronUpdate: vi.fn(),
+  existsSyncMock: vi.fn().mockReturnValue(false),
+  writeChatLog: vi.fn(),
+  mockEnsureMetaAgent: vi.fn().mockResolvedValue(undefined),
+  mockRouteToMetaAgent: vi.fn().mockResolvedValue(undefined),
+  mockParseRoutingTag: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("node-telegram-bot-api", () => ({
+  default: vi.fn(function MockTelegramBot() {
+    return {
+      on: mocks.tgOn,
+      sendMessage: mocks.tgSendMessage,
+      sendDocument: vi.fn().mockResolvedValue({}),
+      sendChatAction: mocks.tgSendChatAction,
+      setMyCommands: mocks.tgSetMyCommands,
+      stopPolling: mocks.tgStopPolling,
+      getFileLink: vi.fn().mockResolvedValue("https://example.com/file"),
+      getMe: mocks.tgGetMe,
+    };
+  }),
+}));
+
+vi.mock("./claude.js", () => ({
+  ClaudeProcess: vi.fn(function MockClaudeProcess() {
+    return {
+      sendPrompt: mocks.claudeSendPrompt,
+      sendImage: vi.fn(),
+      kill: mocks.claudeKill,
+      exited: false,
+      on: mocks.claudeOn,
+    };
+  }),
+  extractText: vi.fn((msg: Record<string, unknown>) => {
+    const payload = msg.payload as Record<string, unknown>;
+    return (payload?.result as string) ?? "";
+  }),
+}));
+
+vi.mock("./cron.js", () => ({
+  CronManager: vi.fn(function MockCronManager() {
+    return {
+      list: mocks.cronList,
+      add: mocks.cronAdd,
+      remove: mocks.cronRemove,
+      clearAll: mocks.cronClearAll,
+      update: mocks.cronUpdate,
+    };
+  }),
+}));
+
+vi.mock("./voice.js", () => ({
+  isVoiceAvailable: vi.fn().mockReturnValue(false),
+  transcribeVoice: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, existsSync: mocks.existsSyncMock };
+});
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, execSync: vi.fn().mockReturnValue(""), spawn: vi.fn() };
+});
+
+vi.mock("./notifier.js", () => ({
+  writeChatLog: mocks.writeChatLog,
+}));
+
+vi.mock("./router.js", () => ({
+  parseRoutingTag: (...args: unknown[]) => mocks.mockParseRoutingTag(...args),
+  ensureMetaAgent: (...args: unknown[]) => mocks.mockEnsureMetaAgent(...args),
+  routeToMetaAgent: (...args: unknown[]) => mocks.mockRouteToMetaAgent(...args),
+}));
+
+import { CcTgBot, normalizeTopicNamespace } from "./bot.js";
+import type { Redis } from "ioredis";
+
+// ---- helpers ----
+function makeRedis(overrides: Record<string, unknown> = {}) {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    rpush: vi.fn().mockResolvedValue(1),
+    ...overrides,
+  } as unknown as Redis;
+}
+
+// chat.type intentionally omitted so isGroup=false — same pattern as bot.test.ts
+function makeMsg(overrides: Record<string, unknown> = {}) {
+  return {
+    chat: { id: 42 },
+    from: { id: 100 },
+    text: "hello",
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// normalizeTopicNamespace
+// ===========================================================================
+describe("normalizeTopicNamespace", () => {
+  it("lowercases the name", () => {
+    expect(normalizeTopicNamespace("MyTopic")).toBe("mytopic");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(normalizeTopicNamespace("CC Suite")).toBe("cc-suite");
+  });
+
+  it("strips leading # chars", () => {
+    expect(normalizeTopicNamespace("#research")).toBe("research");
+    expect(normalizeTopicNamespace("##deep")).toBe("deep");
+  });
+
+  it("leaves already-normalized names unchanged", () => {
+    expect(normalizeTopicNamespace("of-stack")).toBe("of-stack");
+  });
+
+  it("collapses multiple spaces", () => {
+    expect(normalizeTopicNamespace("foo   bar")).toBe("foo-bar");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(normalizeTopicNamespace("foo---bar")).toBe("foo-bar");
+  });
+
+  it("replaces special chars with hyphens and trims them", () => {
+    // trailing ! becomes -, which is trimmed by the final replace
+    expect(normalizeTopicNamespace("My Topic!")).toBe("my-topic");
+    expect(normalizeTopicNamespace("topic!")).toBe("topic");
+  });
+
+  it("handles mixed case, spaces, and # together", () => {
+    expect(normalizeTopicNamespace("#CC Suite")).toBe("cc-suite");
+  });
+});
+
+// ===========================================================================
+// Forum routing in handleTelegram
+// ===========================================================================
+describe("Forum topic meta-agent routing", () => {
+  let bot: CcTgBot;
+  let redis: Redis;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.cronList.mockReturnValue([]);
+    mocks.existsSyncMock.mockReturnValue(false);
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+    delete process.env.FORUM_META_AGENT_ROUTING;
+    delete process.env.DEFAULT_GITHUB_ORG;
+
+    redis = makeRedis();
+    bot = new CcTgBot({ telegramToken: "test-token", redis });
+  });
+
+  afterEach(() => {
+    bot.stop();
+  });
+
+  async function sendMsg(overrides: Record<string, unknown> = {}) {
+    await (bot as unknown as { handleTelegram(m: unknown): Promise<void> }).handleTelegram(
+      makeMsg(overrides)
+    );
+  }
+
+  // ---- topic name caching from service messages ----
+
+  it("caches topic name from forum_topic_created service message", async () => {
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_created: { name: "My Topic" },
+    });
+    const cache = (bot as unknown as { topicNameCache: Map<string, string> }).topicNameCache;
+    expect(cache.get("42:5")).toBe("My Topic");
+  });
+
+  it("updates cached topic name from forum_topic_edited service message", async () => {
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_created: { name: "Old Name" },
+    });
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_edited: { name: "New Name" },
+    });
+    const cache = (bot as unknown as { topicNameCache: Map<string, string> }).topicNameCache;
+    expect(cache.get("42:5")).toBe("New Name");
+  });
+
+  it("does not overwrite cached name when forum_topic_edited has no name field", async () => {
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_created: { name: "Stable Name" },
+    });
+    // Edited event with only icon change (no name field)
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_edited: { icon_color: 123 },
+    });
+    const cache = (bot as unknown as { topicNameCache: Map<string, string> }).topicNameCache;
+    expect(cache.get("42:5")).toBe("Stable Name");
+  });
+
+  it("caches topic name from reply_to_message.forum_topic_created on first real message", async () => {
+    await sendMsg({
+      message_thread_id: 7,
+      text: "hello in topic",
+      reply_to_message: { forum_topic_created: { name: "Dev Chat" } },
+    });
+    const cache = (bot as unknown as { topicNameCache: Map<string, string> }).topicNameCache;
+    expect(cache.get("42:7")).toBe("Dev Chat");
+  });
+
+  // ---- routing logic ----
+
+  it("routes message to meta-agent when topic name is cached and routing=auto", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    // Cache the topic name via service message
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_created: { name: "of-stack" },
+    });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+
+    await sendMsg({ message_thread_id: 5, text: "fix the bug" });
+
+    // Should ack routing in the correct thread
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(
+      42,
+      "→ #of-stack (meta-agent)",
+      expect.objectContaining({ message_thread_id: 5 })
+    );
+    expect(mocks.mockEnsureMetaAgent).toHaveBeenCalledWith(
+      "of-stack",
+      expect.stringContaining("gonzih/of-stack"),
+      expect.any(Function),
+      redis
+    );
+    expect(mocks.mockRouteToMetaAgent).toHaveBeenCalledWith("of-stack", "fix the bug", redis);
+  });
+
+  it("uses DEFAULT_GITHUB_ORG when building repo URL", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    process.env.DEFAULT_GITHUB_ORG = "myorg";
+    await sendMsg({
+      message_thread_id: 3,
+      text: undefined,
+      forum_topic_created: { name: "my-project" },
+    });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+
+    await sendMsg({ message_thread_id: 3, text: "do work" });
+
+    expect(mocks.mockEnsureMetaAgent).toHaveBeenCalledWith(
+      "my-project",
+      "https://github.com/myorg/my-project",
+      expect.any(Function),
+      redis
+    );
+  });
+
+  it("does NOT route when FORUM_META_AGENT_ROUTING=off", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "off";
+    await sendMsg({
+      message_thread_id: 5,
+      text: undefined,
+      forum_topic_created: { name: "of-stack" },
+    });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+
+    await sendMsg({ message_thread_id: 5, text: "hello" });
+
+    expect(mocks.mockEnsureMetaAgent).not.toHaveBeenCalled();
+    expect(mocks.mockRouteToMetaAgent).not.toHaveBeenCalled();
+  });
+
+  it("routes only listed topics when FORUM_META_AGENT_ROUTING is comma-separated", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "of-stack,cc-suite";
+
+    // Cache two topic names
+    await sendMsg({ message_thread_id: 1, text: undefined, forum_topic_created: { name: "of-stack" } });
+    await sendMsg({ message_thread_id: 2, text: undefined, forum_topic_created: { name: "other-topic" } });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+
+    // "of-stack" is in the allowlist → should route
+    await sendMsg({ message_thread_id: 1, text: "work on it" });
+    expect(mocks.mockEnsureMetaAgent).toHaveBeenCalledWith(
+      "of-stack",
+      expect.any(String),
+      expect.any(Function),
+      redis
+    );
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+
+    // "other-topic" is NOT in allowlist → should not route
+    await sendMsg({ message_thread_id: 2, text: "work on it" });
+    expect(mocks.mockEnsureMetaAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT route when topic name is not in cache", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    // No cache population — topic name never seen for threadId 99
+
+    await sendMsg({ message_thread_id: 99, text: "hello" });
+
+    expect(mocks.mockEnsureMetaAgent).not.toHaveBeenCalled();
+    expect(mocks.mockRouteToMetaAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT route when message is not in a forum topic (no threadId)", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+
+    await sendMsg({ text: "hello" }); // no message_thread_id
+
+    expect(mocks.mockEnsureMetaAgent).not.toHaveBeenCalled();
+    expect(mocks.mockRouteToMetaAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT route when Redis is not configured", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    const botNoRedis = new CcTgBot({ telegramToken: "test-token" });
+    // Manually prime its cache
+    (botNoRedis as unknown as { topicNameCache: Map<string, string> }).topicNameCache.set(
+      "42:5",
+      "of-stack"
+    );
+
+    await (botNoRedis as unknown as { handleTelegram(m: unknown): Promise<void> }).handleTelegram(
+      makeMsg({ message_thread_id: 5, text: "hello" })
+    );
+
+    expect(mocks.mockEnsureMetaAgent).not.toHaveBeenCalled();
+    botNoRedis.stop();
+  });
+
+  it("sends failure message in thread when ensureMetaAgent throws", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    await sendMsg({ message_thread_id: 5, text: undefined, forum_topic_created: { name: "bad-topic" } });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockRejectedValue(new Error("agent exploded"));
+
+    await sendMsg({ message_thread_id: 5, text: "do something" });
+
+    const calls = mocks.tgSendMessage.mock.calls as [number, string, unknown?][];
+    const errorCall = calls.find(([, msg]) => (msg as string).includes("Failed to route"));
+    expect(errorCall).toBeDefined();
+    expect(errorCall![1]).toContain("agent exploded");
+    // Error reply must be in the same thread
+    expect(errorCall![2]).toMatchObject({ message_thread_id: 5 });
+  });
+
+  it("normalizes topic name before routing (spaces → hyphens, lowercase)", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    await sendMsg({ message_thread_id: 9, text: undefined, forum_topic_created: { name: "CC Suite" } });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.mockParseRoutingTag.mockReturnValue(null);
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+
+    await sendMsg({ message_thread_id: 9, text: "deploy please" });
+
+    expect(mocks.mockEnsureMetaAgent).toHaveBeenCalledWith(
+      "cc-suite",
+      expect.stringContaining("cc-suite"),
+      expect.any(Function),
+      redis
+    );
+    expect(mocks.mockRouteToMetaAgent).toHaveBeenCalledWith("cc-suite", "deploy please", redis);
+  });
+
+  it("hashtag routing takes priority over forum routing", async () => {
+    process.env.FORUM_META_AGENT_ROUTING = "auto";
+    // Cache a topic name
+    await sendMsg({ message_thread_id: 5, text: undefined, forum_topic_created: { name: "of-stack" } });
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    // Hashtag routing returns a match
+    mocks.mockParseRoutingTag.mockReturnValue({
+      namespace: "other-repo",
+      repoUrl: "https://github.com/gonzih/other-repo",
+      strippedMessage: "fix the bug",
+    });
+    mocks.mockEnsureMetaAgent.mockResolvedValue(undefined);
+    mocks.mockRouteToMetaAgent.mockResolvedValue(undefined);
+
+    await sendMsg({ message_thread_id: 5, text: "#other-repo fix the bug" });
+
+    // Should route to "other-repo" (hashtag routing), NOT "of-stack" (forum routing)
+    expect(mocks.mockRouteToMetaAgent).toHaveBeenCalledWith("other-repo", "fix the bug", redis);
+    // The forum routing ack "(meta-agent)" should NOT appear — hashtag routing sends its own ack
+    const sendCalls = mocks.tgSendMessage.mock.calls as [number, string, unknown?][];
+    const forumAck = sendCalls.find(([, msg]) => (msg as string).includes("(meta-agent)"));
+    expect(forumAck).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Telegram forum topics automatically route messages to meta-agents named after the topic — topic "of-stack" → namespace "of-stack" → meta-agent
- Topic names are cached from `forum_topic_created` / `forum_topic_edited` service messages and from `reply_to_message` on the first real message in a topic
- `FORUM_META_AGENT_ROUTING` env var controls behavior: `auto` (default, routes all topics), `off` (disable), or comma-separated allowlist
- Hashtag routing (`#tag`) takes priority; `THREAD_CWD_MAP` is bypassed when forum routing fires
- Reply in the same topic thread: `→ #namespace (meta-agent)` acknowledges routing

## Test plan
- [x] All 461 existing tests pass
- [x] 21 new tests in `src/forum-routing.test.ts` covering: topic name caching from service messages, `forum_topic_edited`, `reply_to_message` fallback, `auto`/`off`/allowlist config, no-redis guard, error handling, namespace normalization, hashtag priority
- [x] Build passes clean (`tsc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)