### PR TITLE
fix: meta-agent routing — treat idle as ready in ensureMetaAgent

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -146,12 +146,42 @@ describe("ensureMetaAgent", () => {
     expect(mockExecSync).not.toHaveBeenCalled();
   });
 
+  it("returns early when meta-agent is idle (idle = ready)", async () => {
+    mockGet.mockResolvedValue(JSON.stringify({ status: "idle" }));
+    const callTool = vi.fn();
+    const redis = makeRedis();
+
+    await ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis);
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("resolves in poll loop when status becomes idle", async () => {
+    // No status on fast path
+    mockGet.mockResolvedValueOnce(null);
+    // Poll: idle on first tick → should resolve immediately
+    mockGet.mockResolvedValue(JSON.stringify({ status: "idle" }));
+
+    mockExecSync.mockReturnValue("");
+    const callTool = vi.fn().mockResolvedValue("ok");
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("cc-agent", "https://github.com/gonzih/cc-agent", callTool, redis);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
   it("starts meta-agent when not running (repo already exists)", async () => {
     // Not running initially
     mockGet.mockResolvedValueOnce(null);
-    // Poll: not running on first tick, running on second
+    // Poll: idle on first tick → resolves (idle = ready)
     mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));
-    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "running" }));
 
     // gh repo view succeeds (repo exists)
     mockExecSync.mockReturnValue("");

--- a/src/router.ts
+++ b/src/router.ts
@@ -82,12 +82,17 @@ export async function ensureMetaAgent(
   const timeoutMs = parseInt(process.env.META_AGENT_TIMEOUT_MS ?? "10000", 10);
   const statusKey = `cca:meta-agent:status:${namespace}`;
 
-  // Fast path: already running
+  console.log(`[router] ensureMetaAgent namespace=${namespace} checking ${statusKey}`);
+
+  // Fast path: already running or idle (idle = ready to receive messages)
   const statusRaw = await redis.get(statusKey);
   if (statusRaw) {
     try {
       const status = JSON.parse(statusRaw) as { status?: string };
-      if (status.status === "running") return;
+      if (status.status === "running" || status.status === "idle") {
+        console.log(`[router] meta-agent ${namespace} is already ready (status=${status.status})`);
+        return;
+      }
     } catch {
       // Corrupt status value — fall through and restart
     }
@@ -118,7 +123,7 @@ export async function ensureMetaAgent(
     throw new Error(`start_meta_agent returned null — tool may not be available in cc-agent`);
   }
 
-  // Poll until the meta-agent reports "running"
+  // Poll until the meta-agent reports "running" or "idle" (both mean ready)
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, 1000));
@@ -126,10 +131,13 @@ export async function ensureMetaAgent(
     if (raw) {
       try {
         const s = JSON.parse(raw) as { status?: string };
-        if (s.status === "running") return;
+        console.log(`[router] waiting for meta-agent ${namespace} — current status: ${s.status}`);
+        if (s.status === "running" || s.status === "idle") return;
       } catch {
         // ignore parse errors, keep polling
       }
+    } else {
+      console.log(`[router] waiting for meta-agent ${namespace} — no status key yet`);
     }
   }
 


### PR DESCRIPTION
## Summary
- `ensureMetaAgent` was polling for `status === "running"` but `start_meta_agent` in cc-agent only writes `status: "idle"` between messages — `"running"` only appears while actively processing a message
- An idle meta-agent IS ready to receive messages; the check was semantically wrong and always timed out
- Fast path and poll loop now accept both `"idle"` and `"running"` as ready signals
- Added per-second logging in the poll loop and an entry log so future timeouts are diagnosable

## Changes
- `src/router.ts`: fast path + poll loop check `status === "running" || status === "idle"`; added `console.log` at entry, on fast-path hit, and each poll tick
- `src/router.test.ts`: added tests for idle fast-path and idle poll-loop resolution; removed leftover `mockResolvedValueOnce` that became unreachable with the fix

## Test plan
- [x] All 463 tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [x] New test: "returns early when meta-agent is idle (idle = ready)"
- [x] New test: "resolves in poll loop when status becomes idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)