### PR TITLE
fix: poll state key cca:meta:{ns} to fix of-stack cold-start timeout

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -169,8 +169,9 @@ describe("ensureMetaAgent", () => {
   });
 
   it("resolves in poll loop when status becomes idle", async () => {
-    // No status on fast path
-    mockGet.mockResolvedValueOnce(null);
+    // Fast path: both keys absent
+    mockGet.mockResolvedValueOnce(null); // status key
+    mockGet.mockResolvedValueOnce(null); // state key
     // Poll: idle on first tick → should resolve immediately
     mockGet.mockResolvedValue(JSON.stringify({ status: "idle" }));
 
@@ -189,10 +190,11 @@ describe("ensureMetaAgent", () => {
   });
 
   it("starts meta-agent when not running (repo already exists)", async () => {
-    // Not running initially
-    mockGet.mockResolvedValueOnce(null);
+    // Fast path: both keys absent
+    mockGet.mockResolvedValueOnce(null); // status key
+    mockGet.mockResolvedValueOnce(null); // state key
     // Poll: idle on first tick → resolves (idle = ready)
-    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" })); // poll status key
 
     // gh repo view succeeds (repo exists)
     mockExecSync.mockReturnValue("");
@@ -218,8 +220,10 @@ describe("ensureMetaAgent", () => {
   });
 
   it("creates repo when gh repo view fails, then starts meta-agent", async () => {
-    mockGet.mockResolvedValueOnce(null);
-    mockGet.mockResolvedValue(JSON.stringify({ status: "running" }));
+    // Fast path: both keys absent
+    mockGet.mockResolvedValueOnce(null); // status key
+    mockGet.mockResolvedValueOnce(null); // state key
+    mockGet.mockResolvedValue(JSON.stringify({ status: "running" })); // poll
 
     // gh repo view throws (not found), gh repo create succeeds
     mockExecSync
@@ -257,7 +261,7 @@ describe("ensureMetaAgent", () => {
   });
 
   it("throws on timeout when meta-agent never becomes ready", async () => {
-    mockGet.mockResolvedValue(null); // never becomes running
+    mockGet.mockResolvedValue(null); // never becomes running — both status and state keys absent
     mockExecSync.mockReturnValue("");
 
     const callTool = vi.fn().mockResolvedValue("ok");
@@ -273,5 +277,63 @@ describe("ensureMetaAgent", () => {
     const err = await caught;
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain("did not become ready within 3000ms");
+  });
+
+  // The root-cause fix: start_meta_agent writes cca:meta:{namespace} (state key) but NOT
+  // cca:meta-agent:status:{namespace} (status key). The poll must check both.
+  it("resolves when state key appears after start_meta_agent (core bug fix)", async () => {
+    // Fast path: both keys absent
+    mockGet.mockResolvedValueOnce(null); // fast path: status key
+    mockGet.mockResolvedValueOnce(null); // fast path: state key
+    // Poll iteration 1: status key absent, state key has idle (written by startMetaAgent)
+    mockGet.mockResolvedValueOnce(null);                                      // poll: status key
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));        // poll: state key
+
+    mockExecSync.mockReturnValue("");
+    const callTool = vi.fn().mockResolvedValue(
+      JSON.stringify({ ok: true, namespace: "of-stack", status: "idle" })
+    );
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("of-stack", "https://github.com/gonzih/of-stack", callTool, redis);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(callTool).toHaveBeenCalledWith("start_meta_agent", {
+      namespace: "of-stack",
+      repo_url: "https://github.com/gonzih/of-stack",
+    });
+  });
+
+  it("returns early on fast path when state key shows idle (workspace pre-exists)", async () => {
+    // Status key absent, state key present with idle — workspace already created
+    mockGet.mockResolvedValueOnce(null);                                 // status key
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));  // state key
+
+    const callTool = vi.fn();
+    const redis = makeRedis();
+
+    await ensureMetaAgent("of-stack", "https://github.com/gonzih/of-stack", callTool, redis);
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("throws when start_meta_agent returns ok:false error payload", async () => {
+    mockGet.mockResolvedValueOnce(null); // status key
+    mockGet.mockResolvedValueOnce(null); // state key
+    mockExecSync.mockReturnValue("");
+
+    const callTool = vi.fn().mockResolvedValue(
+      JSON.stringify({ ok: false, error: "git clone failed: repository not found" })
+    );
+    const redis = makeRedis();
+
+    await expect(
+      ensureMetaAgent("of-stack", "https://github.com/gonzih/of-stack", callTool, redis)
+    ).rejects.toThrow("start_meta_agent failed: git clone failed: repository not found");
   });
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -68,10 +68,19 @@ export function parseRoutingTag(text: string): RoutingTag | null {
  * Ensure a meta-agent for the given namespace is running.
  *
  * Steps:
- *   1. Check cca:meta-agent:status:{namespace} in Redis — return early if already running.
+ *   1. Check Redis for readiness via two keys (see below) — return early if already ready.
  *   2. Verify the GitHub repo exists; create it (public) if not.
  *   3. Call the start_meta_agent MCP tool via callTool.
- *   4. Poll the Redis status key every 1s until running or META_AGENT_TIMEOUT_MS expires.
+ *   4. Poll both Redis keys every 1s until ready or META_AGENT_TIMEOUT_MS expires.
+ *
+ * Two Redis keys are checked:
+ *   cca:meta-agent:status:{namespace} — live-status key written by writeLiveStatus()
+ *     (only populated after the first message is processed by messageMetaAgent)
+ *   cca:meta:{namespace} — state key written by startMetaAgent() directly via saveState()
+ *     (populated as soon as the workspace is created, with status:"idle")
+ *
+ * Bug context: start_meta_agent writes cca:meta:{namespace} but NOT cca:meta-agent:status:{namespace}.
+ * Polling only the status key caused a 10s timeout on every cold start.
  *
  * Throws on failure (repo creation error, tool call failure, or timeout).
  */
@@ -83,10 +92,12 @@ export async function ensureMetaAgent(
 ): Promise<void> {
   const timeoutMs = parseInt(process.env.META_AGENT_TIMEOUT_MS ?? "10000", 10);
   const statusKey = `cca:meta-agent:status:${namespace}`;
+  // State key written by startMetaAgent() directly — the source of truth for workspace existence.
+  const stateKey = `cca:meta:${namespace}`;
 
-  console.log(`[router] ensureMetaAgent namespace=${namespace} checking ${statusKey}`);
+  console.log(`[router] ensureMetaAgent namespace=${namespace}`);
 
-  // Fast path: already running or idle (idle = ready to receive messages)
+  // Fast path: check live-status key (written by messageMetaAgent after first message)
   const statusRaw = await redis.get(statusKey);
   if (statusRaw) {
     try {
@@ -96,7 +107,22 @@ export async function ensureMetaAgent(
         return;
       }
     } catch {
-      // Corrupt status value — fall through and restart
+      // Corrupt status value — fall through
+    }
+  }
+
+  // Fast path: also check state key (written by startMetaAgent, persists 30 days).
+  // Presence of this key means the workspace was already created — no need to re-run start_meta_agent.
+  const stateRaw = await redis.get(stateKey);
+  if (stateRaw) {
+    try {
+      const state = JSON.parse(stateRaw) as { status?: string };
+      if (state.status === "idle" || state.status === "running") {
+        console.log(`[router] meta-agent ${namespace} workspace exists (state.status=${state.status})`);
+        return;
+      }
+    } catch {
+      // Corrupt state — fall through and re-initialize
     }
   }
 
@@ -119,27 +145,53 @@ export async function ensureMetaAgent(
     }
   }
 
-  // Start the meta-agent via MCP
+  // Start the meta-agent via MCP (clones workspace if needed, writes cca:meta:{namespace})
   const result = await callTool("start_meta_agent", { namespace, repo_url: repoUrl });
   if (result === null) {
     throw new Error(`start_meta_agent returned null — tool may not be available in cc-agent`);
   }
 
-  // Poll until the meta-agent reports "running" or "idle" (both mean ready)
+  // Check for explicit failure payload (e.g. git clone error)
+  try {
+    const parsed = JSON.parse(result) as { ok?: boolean; error?: string };
+    if (parsed.ok === false) {
+      throw new Error(`start_meta_agent failed: ${parsed.error ?? "unknown error"}`);
+    }
+  } catch (jsonErr) {
+    if (!(jsonErr instanceof SyntaxError)) throw jsonErr;
+    // Non-JSON result (e.g. plain "ok") — not an error, continue to poll
+  }
+
+  // Poll until ready. Check both keys:
+  //   - statusKey: written by writeLiveStatus() during messageMetaAgent (may not exist yet on cold start)
+  //   - stateKey:  written by startMetaAgent() above — will appear within 1s of the tool call returning
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+
     const raw = await redis.get(statusKey);
     if (raw) {
       try {
         const s = JSON.parse(raw) as { status?: string };
-        console.log(`[router] waiting for meta-agent ${namespace} — current status: ${s.status}`);
+        console.log(`[router] waiting for meta-agent ${namespace} — status key: ${s.status}`);
         if (s.status === "running" || s.status === "idle") return;
       } catch {
         // ignore parse errors, keep polling
       }
+    }
+
+    // Also check state key — startMetaAgent writes this synchronously before responding
+    const state = await redis.get(stateKey);
+    if (state) {
+      try {
+        const s = JSON.parse(state) as { status?: string };
+        console.log(`[router] waiting for meta-agent ${namespace} — state key: ${s.status}`);
+        if (s.status === "idle" || s.status === "running") return;
+      } catch {
+        // ignore parse errors, keep polling
+      }
     } else {
-      console.log(`[router] waiting for meta-agent ${namespace} — no status key yet`);
+      console.log(`[router] waiting for meta-agent ${namespace} — neither key present yet`);
     }
   }
 


### PR DESCRIPTION
## Root Cause

`ensureMetaAgent` was polling only `cca:meta-agent:status:{namespace}`, but `start_meta_agent` (in cc-agent) **never writes that key** on cold start.

`startMetaAgent()` writes `cca:meta:{namespace}` via `saveState()` with `status:"idle"`, but `cca:meta-agent:status:{namespace}` is only populated by `writeLiveStatus()` — which runs inside `messageMetaAgent()` *after the first message is processed*.

Result: every cold-start poll timed out after 10s with:
```
Meta-agent for of-stack did not become ready within 10000ms
```

## Fix

Poll **both** Redis keys in the fast path and poll loop:

| Key | Written by | When |
|-----|-----------|------|
| `cca:meta-agent:status:{ns}` | `writeLiveStatus()` | During `messageMetaAgent()` — not on startup |
| `cca:meta:{ns}` | `startMetaAgent()` via `saveState()` | Synchronously, before tool response returns |

With this fix, the first poll iteration (1s after `start_meta_agent` returns) finds `cca:meta:{ns}` with `status:"idle"` and returns immediately.

**Also:**
- Fast path now returns early if either key shows ready — avoids redundant `start_meta_agent` calls when workspace already exists
- Parse `start_meta_agent` result for `ok:false` to surface git clone errors early rather than polling for 10s

## Tests

- 3 new tests covering: core bug fix (state key resolves poll), fast-path on state key, `ok:false` error propagation
- 3 existing tests updated: fast path now makes 2 `redis.get()` calls so mocks needed a second `null` queued

All 467 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)