### PR TITLE
feat: forward meta-agent responses back to Telegram for routed namespaces

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -48,6 +48,9 @@ export interface BotOptions {
   groupChatIds?: number[];
   redis?: Redis;
   namespace?: string;
+  /** Called when a message is routed to a non-default namespace so the notifier
+   *  can forward the response back to the originating Telegram chat. */
+  registerRoutedChatId?: (namespace: string, chatId: number) => void;
 }
 
 interface Session {
@@ -547,6 +550,8 @@ export class CcTgBot {
         // Acknowledge routing immediately so user knows the message was delegated
         await this.replyToChat(chatId, `→ #${routing.namespace}`, threadId);
         this.writeChatMessage("user", "telegram", text, chatId);
+        // Register the originating chatId so responses come back to this chat
+        this.opts.registerRoutedChatId?.(routing.namespace, chatId);
         try {
           await ensureMetaAgent(
             routing.namespace,
@@ -581,6 +586,8 @@ export class CcTgBot {
           const repoUrl = `https://github.com/${defaultOrg}/${namespace}`;
           await this.replyToChat(chatId, `→ #${namespace} (meta-agent)`, threadId);
           this.writeChatMessage("user", "telegram", text, chatId);
+          // Register the originating chatId so responses come back to this chat
+          this.opts.registerRoutedChatId?.(namespace, chatId);
           try {
             await ensureMetaAgent(
               namespace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,30 @@ sharedRedis.once("ready", () => {
   console.log(`[cc-tg] version:reported ${pkg.version}`);
 });
 
+// Notifier — always subscribe to cca:notify and cca:chat:incoming channels.
+// CC_AGENT_NOTIFY_CHAT_ID pins a fixed Telegram chatId; without it the last
+// active chatId is used dynamically for the chat bridge.
+// Created before the bot so we can pass registerRoutedChatId into BotOptions.
+// Callbacks are wired via closures that delegate to the bot after it is created.
+const notifyChatId = process.env.CC_AGENT_NOTIFY_CHAT_ID
+  ? Number(process.env.CC_AGENT_NOTIFY_CHAT_ID)
+  : null;
+
+// Mutable placeholder closures — filled in once `bot` is created below.
+let getLastActiveChatIdFn: () => number | undefined = () => undefined;
+let handleUserMessageFn: ((chatId: number, text: string) => void) | undefined;
+
+const notifierBot = new TelegramBot(telegramToken, { polling: false });
+const notifier = startNotifier(
+  notifierBot,
+  notifyChatId,
+  namespace,
+  sharedRedis,
+  (cid, text) => handleUserMessageFn?.(cid, text),
+  () => getLastActiveChatIdFn(),
+);
+console.log(`[notifier] started for namespace=${namespace} chatId=${notifyChatId ?? "dynamic"}`);
+
 const bot = new CcTgBot({
   telegramToken,
   claudeToken,
@@ -153,7 +177,12 @@ const bot = new CcTgBot({
   groupChatIds,
   redis: sharedRedis,
   namespace,
+  registerRoutedChatId: (ns, chatId) => notifier.registerRoutedChatId(ns, chatId),
 });
+
+// Wire closures now that bot is constructed
+getLastActiveChatIdFn = () => bot.getLastActiveChatId();
+handleUserMessageFn = (cid, text) => { void bot.handleUserMessage(cid, text); };
 
 if (process.env.CC_AGENT_OPS_PORT) {
   const botInfo = await bot.getMe();
@@ -177,24 +206,6 @@ if (process.env.CC_AGENT_OPS_PORT) {
   });
   console.log(`[ops] control server on port ${process.env.CC_AGENT_OPS_PORT}`);
 }
-
-// Notifier — always subscribe to cca:notify and cca:chat:incoming channels.
-// CC_AGENT_NOTIFY_CHAT_ID pins a fixed Telegram chatId; without it the last
-// active chatId is used dynamically for the chat bridge.
-const notifyChatId = process.env.CC_AGENT_NOTIFY_CHAT_ID
-  ? Number(process.env.CC_AGENT_NOTIFY_CHAT_ID)
-  : null;
-
-const notifierBot = new TelegramBot(telegramToken, { polling: false });
-startNotifier(
-  notifierBot,
-  notifyChatId,
-  namespace,
-  sharedRedis,
-  (cid, text) => bot.handleUserMessage(cid, text),
-  () => bot.getLastActiveChatId()
-);
-console.log(`[notifier] started for namespace=${namespace} chatId=${notifyChatId ?? "dynamic"}`);
 
 process.on("SIGINT", () => {
   console.log("\nShutting down...");

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -575,6 +575,98 @@ describe("meta-agent outgoing (pmessage)", () => {
 
     expect(bot.sendMessage).not.toHaveBeenCalled();
   });
+
+  describe("registerRoutedChatId", () => {
+    it("routes response to registered chatId instead of fixed chatId", async () => {
+      const bot = makeBot();
+      const redis = makeRedis();
+      const pmessage = capturePmessageHandler();
+
+      // Fixed chatId=99 (e.g., money-brain), but we route from chatId=777
+      const notifier = startNotifier(bot as never, 99, "money-brain", redis as never);
+      notifier.registerRoutedChatId("of-stack", 777);
+
+      pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:of-stack",
+        JSON.stringify({ source: "claude", content: "done routing" }));
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Must go to 777 (originating chat), not 99 (fixed chat)
+      expect(bot.sendMessage).toHaveBeenCalledWith(777, "done routing");
+      expect(bot.sendMessage).not.toHaveBeenCalledWith(99, "done routing");
+    });
+
+    it("falls back to fixed chatId when no routing registered for namespace", async () => {
+      const bot = makeBot();
+      const redis = makeRedis();
+      const pmessage = capturePmessageHandler();
+
+      const notifier = startNotifier(bot as never, 99, "money-brain", redis as never);
+      // Register for a different namespace — should not affect of-stack
+      notifier.registerRoutedChatId("other-ns", 888);
+
+      pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:of-stack",
+        JSON.stringify({ source: "claude", content: "unregistered namespace" }));
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Falls back to fixed chatId=99
+      expect(bot.sendMessage).toHaveBeenCalledWith(99, "unregistered namespace");
+    });
+
+    it("last registerRoutedChatId call wins for same namespace", async () => {
+      const bot = makeBot();
+      const redis = makeRedis();
+      const pmessage = capturePmessageHandler();
+
+      const notifier = startNotifier(bot as never, 99, "money-brain", redis as never);
+      notifier.registerRoutedChatId("of-stack", 111);
+      notifier.registerRoutedChatId("of-stack", 222); // overwrites
+
+      pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:of-stack",
+        JSON.stringify({ source: "claude", content: "overwritten" }));
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(bot.sendMessage).toHaveBeenCalledWith(222, "overwritten");
+    });
+
+    it("falls back to getActiveChatId when no fixed chatId and no routing for namespace", async () => {
+      const bot = makeBot();
+      const redis = makeRedis();
+      const getActiveChatId = vi.fn().mockReturnValue(555);
+      const pmessage = capturePmessageHandler();
+
+      const notifier = startNotifier(bot as never, null, "money-brain", redis as never, undefined, getActiveChatId);
+      // Register for a different namespace — of-stack not registered
+      notifier.registerRoutedChatId("other-ns", 999);
+
+      pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:of-stack",
+        JSON.stringify({ source: "claude", content: "dynamic fallback" }));
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Falls back to getActiveChatId()
+      expect(bot.sendMessage).toHaveBeenCalledWith(555, "dynamic fallback");
+    });
+
+    it("per-namespace registry does not interfere with primary namespace routing", async () => {
+      const bot = makeBot();
+      const redis = makeRedis();
+      const pmessage = capturePmessageHandler();
+
+      const notifier = startNotifier(bot as never, 99, "money-brain", redis as never);
+      notifier.registerRoutedChatId("of-stack", 777);
+
+      // Primary namespace response — should still go to fixed chatId=99
+      pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:money-brain",
+        JSON.stringify({ source: "claude", content: "primary response" }));
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(bot.sendMessage).toHaveBeenCalledWith(99, "primary response");
+    });
+  });
 });
 
 describe("notify list poller", () => {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -107,6 +107,17 @@ export function writeChatLog(
   });
 }
 
+export interface NotifierHandle {
+  /**
+   * Register the originating Telegram chat ID for a routed namespace.
+   * When the meta-agent for `namespace` publishes a response, it will be
+   * forwarded to `chatId` instead of the global fixed/dynamic chatId.
+   * Call this before routing each message to ensure the response returns
+   * to the correct chat.
+   */
+  registerRoutedChatId: (namespace: string, chatId: number) => void;
+}
+
 /**
  * Start the notifier.
  *
@@ -116,6 +127,8 @@ export function writeChatLog(
  * @param redis     - ioredis client in normal mode (will be duplicated for pub/sub)
  * @param handleUserMessage - Optional callback to feed UI messages into the active Claude session
  * @param getActiveChatId   - Optional callback to resolve chatId dynamically (used when chatId is null)
+ *
+ * @returns NotifierHandle with registerRoutedChatId for per-namespace response routing
  */
 export function startNotifier(
   bot: TelegramBot,
@@ -124,7 +137,10 @@ export function startNotifier(
   redis: Redis,
   handleUserMessage?: (chatId: number, text: string) => void,
   getActiveChatId?: () => number | undefined
-): void {
+): NotifierHandle {
+  // Per-namespace chatId registry: when a message is routed to a non-default namespace,
+  // the originating Telegram chatId is registered here so responses go back to the right chat.
+  const routedChatIds = new Map<string, number>();
   const sub = redis.duplicate({
     retryStrategy: (times: number) => {
       const delay = Math.min(1000 * Math.pow(2, times - 1), 30_000);
@@ -206,7 +222,9 @@ export function startNotifier(
     const content = parsed.content;
     if (!content) return;
 
-    const targetChatId = chatId ?? getActiveChatId?.();
+    // Per-namespace chatId wins (set by registerRoutedChatId when a message is routed).
+    // Falls back to the global fixed chatId or the last-active dynamic chatId.
+    const targetChatId = routedChatIds.get(ns) ?? chatId ?? getActiveChatId?.();
     if (targetChatId == null) {
       log("warn", `meta-agent output: no chatId for namespace=${ns}, dropping line`);
       return;
@@ -360,4 +378,10 @@ export function startNotifier(
       }
     }
   });
+
+  return {
+    registerRoutedChatId: (ns: string, cid: number) => {
+      routedChatIds.set(ns, cid);
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Fixes the bug where `#of-stack` (and any non-default namespace) responses were delivered to the wrong Telegram chat
- Root cause: `pmessage` handler in notifier used `chatId ?? getActiveChatId()` — always the global/fixed chatId or last-active, never the chat that triggered the routing
- Fix: add a per-namespace `Map<string, number>` registry in `startNotifier`; expose `registerRoutedChatId(ns, chatId)` via `NotifierHandle`; bot calls it in both `#tag` and forum-topic routing paths before pushing to the meta-agent input queue

## Changes

- `src/notifier.ts`: new `NotifierHandle` interface, `routedChatIds` Map, `pmessage` handler checks registry first, `startNotifier` returns `NotifierHandle`
- `src/bot.ts`: `registerRoutedChatId?` in `BotOptions`; called in `#tag` routing and forum-topic routing
- `src/index.ts`: create notifier before bot (using closure vars for callbacks), wire `registerRoutedChatId` into bot options
- `src/notifier.test.ts`: 5 new tests covering all registry cases

## Test plan

- [x] `npm test` — 472 tests passing (5 new)
- [x] `npm run build` — clean TypeScript compilation
- [x] Existing multi-namespace test (`cca:chat:outgoing:isoc-nevada` → chatId=99) still passes (fallback path)
- [x] New tests: per-namespace registry routes to correct chatId, fallback works, last-write wins, primary namespace unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)