### PR TITLE
feat: migrate to cc-wire + add <- meta-agent tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",
+        "@gonzih/cc-wire": "^0.1.0",
         "node-telegram-bot-api": "^0.66.0"
       },
       "bin": {
@@ -206,6 +207,12 @@
       "bin": {
         "agent-ops": "dist/ops-bot.js"
       }
+    },
+    "node_modules/@gonzih/cc-wire": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.0.tgz",
+      "integrity": "sha512-vhCOtK7IS6NsdZhkpByVHEKmrcCdJURe+Zplgaj+awjiDL/ZGbD6ukbYF/FmgMYMzJD+MaXhUFscWEeIaWroGQ==",
+      "license": "MIT"
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@gonzih/agent-ops": "^0.1.0",
+    "@gonzih/cc-wire": "^0.1.0",
     "node-telegram-bot-api": "^0.66.0"
   },
   "devDependencies": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -19,6 +19,7 @@ import { getCurrentToken, rotateToken, getTokenIndex, getTokenCount } from "./to
 import { writeChatLog, type ChatMessage } from "./notifier.js";
 import { CronManager } from "./cron.js";
 import { parseRoutingTag, ensureMetaAgent, routeToMetaAgent } from "./router.js";
+import { VOICE_PENDING_KEY, VOICE_FAILED_KEY, TTL, metaAgentStatusKey } from "@gonzih/cc-wire";
 
 const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "start", description: "Reset session and start fresh" },
@@ -655,7 +656,7 @@ export class CcTgBot {
       timestamp: Date.now(),
     });
     if (this.redis) {
-      await this.redis.rpush("voice:pending", pendingEntry).catch((err: Error) =>
+      await this.redis.rpush(VOICE_PENDING_KEY, pendingEntry).catch((err: Error) =>
         console.warn("[voice] redis rpush voice:pending failed:", err.message)
       );
     }
@@ -667,7 +668,7 @@ export class CcTgBot {
 
       // Remove from pending on success
       if (this.redis) {
-        await this.redis.lrem("voice:pending", 0, pendingEntry).catch((err: Error) =>
+        await this.redis.lrem(VOICE_PENDING_KEY, 0, pendingEntry).catch((err: Error) =>
           console.warn("[voice] redis lrem voice:pending failed:", err.message)
         );
       }
@@ -703,8 +704,8 @@ export class CcTgBot {
           error: errMsg,
           failed_at: Date.now(),
         });
-        this.redis.rpush("voice:failed", failedEntry)
-          .then(() => this.redis!.expire("voice:failed", 48 * 60 * 60))
+        this.redis.rpush(VOICE_FAILED_KEY, failedEntry)
+          .then(() => this.redis!.expire(VOICE_FAILED_KEY, TTL.VOICE_FAILED_SECONDS))
           .catch((redisErr: Error) =>
             console.warn("[voice] redis write voice:failed failed:", redisErr.message)
           );
@@ -732,8 +733,8 @@ export class CcTgBot {
     }
 
     const [pendingRaw, failedRaw] = await Promise.all([
-      this.redis.lrange("voice:pending", 0, -1).catch(() => [] as string[]),
-      this.redis.lrange("voice:failed", 0, -1).catch(() => [] as string[]),
+      this.redis.lrange(VOICE_PENDING_KEY, 0, -1).catch(() => [] as string[]),
+      this.redis.lrange(VOICE_FAILED_KEY, 0, -1).catch(() => [] as string[]),
     ]);
 
     // Deduplicate by file_id across both lists
@@ -769,8 +770,8 @@ export class CcTgBot {
           // Remove from both lists
           const matchPending = pendingRaw.find((r) => r.includes(`"${fileId}"`));
           const matchFailed = failedRaw.find((r) => r.includes(`"${fileId}"`));
-          if (matchPending) await this.redis.lrem("voice:pending", 0, matchPending).catch(() => {});
-          if (matchFailed) await this.redis.lrem("voice:failed", 0, matchFailed).catch(() => {});
+          if (matchPending) await this.redis.lrem(VOICE_PENDING_KEY, 0, matchPending).catch(() => {});
+          if (matchFailed) await this.redis.lrem(VOICE_FAILED_KEY, 0, matchFailed).catch(() => {});
 
           succeeded++;
         } else {
@@ -784,7 +785,7 @@ export class CcTgBot {
         // Permanently unretryable (expired Telegram link) — remove from voice:pending
         if (errMsg.includes("Bad Request") || errMsg.includes("file_id")) {
           const matchPending = pendingRaw.find((r) => r.includes(`"${fileId}"`));
-          if (matchPending) await this.redis.lrem("voice:pending", 0, matchPending).catch(() => {});
+          if (matchPending) await this.redis.lrem(VOICE_PENDING_KEY, 0, matchPending).catch(() => {});
         }
       }
     }
@@ -796,7 +797,7 @@ export class CcTgBot {
       try {
         const entry = JSON.parse(raw) as { timestamp?: number };
         if (entry.timestamp && Date.now() - entry.timestamp > staleThreshold) {
-          await this.redis.lrem("voice:pending", 0, raw).catch(() => {});
+          await this.redis.lrem(VOICE_PENDING_KEY, 0, raw).catch(() => {});
           purged++;
         }
       } catch { /* skip malformed entries */ }
@@ -1512,7 +1513,7 @@ export class CcTgBot {
       const keys: string[] = [];
       let cursor = "0";
       do {
-        const [nextCursor, found] = await this.redis.scan(cursor, "MATCH", "cca:meta-agent:status:*", "COUNT", 100);
+        const [nextCursor, found] = await this.redis.scan(cursor, "MATCH", metaAgentStatusKey("*"), "COUNT", 100);
         cursor = nextCursor;
         keys.push(...found);
       } while (cursor !== "0");
@@ -1528,7 +1529,7 @@ export class CcTgBot {
 
       const lines = ["🤖 Active Agents", ""];
       for (const { key, raw } of statuses) {
-        const namespace = key.replace("cca:meta-agent:status:", "");
+        const namespace = key.slice(metaAgentStatusKey("").length);
         if (!raw) {
           lines.push(`${namespace} — status unknown`);
           continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { Registry, startControlServer } from "@gonzih/agent-ops";
 import { Redis } from "ioredis";
 import { startNotifier } from "./notifier.js";
 import { seedClaudeMd } from "./seed.js";
+import { CC_TG_VERSION_KEY } from "@gonzih/cc-wire";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -139,7 +140,7 @@ sharedRedis.on("error", (err: Error) => {
   console.warn("[redis] connection error:", err.message);
 });
 sharedRedis.once("ready", () => {
-  sharedRedis.set("cca:meta:cc-tg:version", pkg.version).catch((err: Error) => {
+  sharedRedis.set(CC_TG_VERSION_KEY, pkg.version).catch((err: Error) => {
     console.warn("[redis] failed to write version:", err.message);
   });
   console.log(`[cc-tg] version:reported ${pkg.version}`);

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -433,7 +433,7 @@ describe("meta-agent outgoing (pmessage)", () => {
     await vi.advanceTimersByTimeAsync(1500);
 
     expect(bot.sendMessage).toHaveBeenCalledTimes(1);
-    expect(bot.sendMessage).toHaveBeenCalledWith(42, "Hello\nWorld");
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "← Hello\nWorld");
   });
 
   it("filters out non-claude sources (echo guard)", async () => {
@@ -483,7 +483,7 @@ describe("meta-agent outgoing (pmessage)", () => {
 
     await vi.advanceTimersByTimeAsync(1500);
 
-    expect(bot.sendMessage).toHaveBeenCalledWith(99, "isoc response");
+    expect(bot.sendMessage).toHaveBeenCalledWith(99, "← isoc response");
   });
 
   it("resets debounce timer when new line arrives within 1.5s", async () => {
@@ -511,7 +511,7 @@ describe("meta-agent outgoing (pmessage)", () => {
     // Advance remaining 500ms to complete the 1.5s debounce
     await vi.advanceTimersByTimeAsync(500);
     expect(bot.sendMessage).toHaveBeenCalledTimes(1);
-    expect(bot.sendMessage).toHaveBeenCalledWith(42, "line 1\nline 2");
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "← line 1\nline 2");
   });
 
   it("uses getActiveChatId when chatId is null", async () => {
@@ -527,7 +527,7 @@ describe("meta-agent outgoing (pmessage)", () => {
 
     await vi.advanceTimersByTimeAsync(1500);
 
-    expect(bot.sendMessage).toHaveBeenCalledWith(77, "dynamic chat");
+    expect(bot.sendMessage).toHaveBeenCalledWith(77, "← dynamic chat");
   });
 
   it("drops message when no chatId is available", async () => {
@@ -558,7 +558,7 @@ describe("meta-agent outgoing (pmessage)", () => {
 
     await vi.advanceTimersByTimeAsync(1500);
 
-    expect(bot.sendMessage).toHaveBeenCalledWith(42, "green text");
+    expect(bot.sendMessage).toHaveBeenCalledWith(42, "← green text");
   });
 
   it("skips lines with empty content", async () => {
@@ -592,8 +592,8 @@ describe("meta-agent outgoing (pmessage)", () => {
       await vi.advanceTimersByTimeAsync(1500);
 
       // Must go to 777 (originating chat), not 99 (fixed chat)
-      expect(bot.sendMessage).toHaveBeenCalledWith(777, "done routing");
-      expect(bot.sendMessage).not.toHaveBeenCalledWith(99, "done routing");
+      expect(bot.sendMessage).toHaveBeenCalledWith(777, "← done routing");
+      expect(bot.sendMessage).not.toHaveBeenCalledWith(99, "← done routing");
     });
 
     it("falls back to fixed chatId when no routing registered for namespace", async () => {
@@ -611,7 +611,7 @@ describe("meta-agent outgoing (pmessage)", () => {
       await vi.advanceTimersByTimeAsync(1500);
 
       // Falls back to fixed chatId=99
-      expect(bot.sendMessage).toHaveBeenCalledWith(99, "unregistered namespace");
+      expect(bot.sendMessage).toHaveBeenCalledWith(99, "← unregistered namespace");
     });
 
     it("last registerRoutedChatId call wins for same namespace", async () => {
@@ -628,7 +628,7 @@ describe("meta-agent outgoing (pmessage)", () => {
 
       await vi.advanceTimersByTimeAsync(1500);
 
-      expect(bot.sendMessage).toHaveBeenCalledWith(222, "overwritten");
+      expect(bot.sendMessage).toHaveBeenCalledWith(222, "← overwritten");
     });
 
     it("falls back to getActiveChatId when no fixed chatId and no routing for namespace", async () => {
@@ -647,7 +647,7 @@ describe("meta-agent outgoing (pmessage)", () => {
       await vi.advanceTimersByTimeAsync(1500);
 
       // Falls back to getActiveChatId()
-      expect(bot.sendMessage).toHaveBeenCalledWith(555, "dynamic fallback");
+      expect(bot.sendMessage).toHaveBeenCalledWith(555, "← dynamic fallback");
     });
 
     it("per-namespace registry does not interfere with primary namespace routing", async () => {
@@ -664,7 +664,7 @@ describe("meta-agent outgoing (pmessage)", () => {
 
       await vi.advanceTimersByTimeAsync(1500);
 
-      expect(bot.sendMessage).toHaveBeenCalledWith(99, "primary response");
+      expect(bot.sendMessage).toHaveBeenCalledWith(99, "← primary response");
     });
   });
 });

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -13,6 +13,14 @@
 
 import { Redis } from "ioredis";
 import TelegramBot from "node-telegram-bot-api";
+import {
+  chatLogKey,
+  chatOutgoingChannel,
+  chatIncomingChannel,
+  notifyChannel,
+  metaAgentStatusKey,
+  metaInputKey,
+} from "@gonzih/cc-wire";
 import { splitLongMessage } from "./formatter.js";
 
 export interface ChatMessage {
@@ -92,8 +100,8 @@ export function writeChatLog(
   namespace: string,
   msg: ChatMessage
 ): void {
-  const logKey = `cca:chat:log:${namespace}`;
-  const outKey = `cca:chat:outgoing:${namespace}`;
+  const logKey = chatLogKey(namespace);
+  const outKey = chatOutgoingChannel(namespace);
   const payload = JSON.stringify(msg);
   // LIFO — newest first. Consumers must LRANGE 0 N then reverse for chronological order.
   redis.lpush(logKey, payload).catch((err: Error) => {
@@ -157,31 +165,31 @@ export function startNotifier(
     log("info", "subscriber disconnected, will reconnect with backoff");
   });
 
-  // cca:notify:{namespace} — forward job completion notifications to Telegram
-  sub.subscribe(`cca:notify:${namespace}`, (err) => {
+  // notifyChannel(namespace) — forward job completion notifications to Telegram
+  sub.subscribe(notifyChannel(namespace), (err) => {
     if (err) {
-      log("error", `subscribe cca:notify:${namespace} failed:`, err.message);
+      log("error", `subscribe ${notifyChannel(namespace)} failed:`, err.message);
     } else {
-      log("info", `subscribed to cca:notify:${namespace}`);
+      log("info", `subscribed to ${notifyChannel(namespace)}`);
     }
   });
 
-  // cca:chat:incoming:{namespace} — messages from UI
-  sub.subscribe(`cca:chat:incoming:${namespace}`, (err) => {
+  // chatIncomingChannel(namespace) — messages from UI
+  sub.subscribe(chatIncomingChannel(namespace), (err) => {
     if (err) {
-      log("error", `subscribe cca:chat:incoming:${namespace} failed:`, err.message);
+      log("error", `subscribe ${chatIncomingChannel(namespace)} failed:`, err.message);
     } else {
-      log("info", `subscribed to cca:chat:incoming:${namespace}`);
+      log("info", `subscribed to ${chatIncomingChannel(namespace)}`);
     }
   });
 
-  // cca:chat:outgoing:* — meta-agent stdout lines (source=claude) → buffer+debounce → Telegram
+  // chatOutgoingChannel("*") — meta-agent stdout lines (source=claude) → buffer+debounce → Telegram
   // Using psubscribe so we catch all namespaces (money-brain, isoc-nevada, etc.)
-  sub.psubscribe("cca:chat:outgoing:*", (err) => {
+  sub.psubscribe(chatOutgoingChannel("*"), (err) => {
     if (err) {
-      log("error", "psubscribe cca:chat:outgoing:* failed:", err.message);
+      log("error", `psubscribe ${chatOutgoingChannel("*")} failed:`, err.message);
     } else {
-      log("info", "psubscribed to cca:chat:outgoing:*");
+      log("info", `psubscribed to ${chatOutgoingChannel("*")}`);
     }
   });
 
@@ -193,7 +201,7 @@ export function startNotifier(
   function flushMetaAgentBuffer(ns: string, targetChatId: number): void {
     const buf = metaAgentBuffers.get(ns);
     if (!buf || !buf.text.trim()) return;
-    const text = stripAnsi(buf.text.trim());
+    const text = "← " + stripAnsi(buf.text.trim());
     buf.text = "";
     buf.timer = null;
     const chunks = splitLongMessage(text);
@@ -206,7 +214,7 @@ export function startNotifier(
 
   sub.on("pmessage", (pattern: string, channel: string, message: string) => {
     void pattern; // used only as a type guard
-    const ns = channel.replace("cca:chat:outgoing:", "");
+    const ns = channel.slice(chatOutgoingChannel("").length);
 
     let parsed: { source?: string; content?: string } | null = null;
     try {
@@ -241,9 +249,9 @@ export function startNotifier(
     buf.timer = setTimeout(() => flushMetaAgentBuffer(ns, targetChatId), META_AGENT_FLUSH_DELAY_MS);
   });
 
-  // Poll the cca:notify:{namespace} LIST every 5 seconds.
+  // Poll the notifyChannel(namespace) LIST every 5 seconds.
   // Jobs push to this list via RPUSH; pub/sub alone won't deliver those messages.
-  const notifyListKey = `cca:notify:${namespace}`;
+  const notifyListKey = notifyChannel(namespace);
   const MAX_PER_CYCLE = 20;
 
   const pollNotifyList = async (): Promise<void> => {
@@ -295,10 +303,10 @@ export function startNotifier(
   }, 5_000);
 
   sub.on("message", (channel: string, message: string) => {
-    const notifyChannel = `cca:notify:${namespace}`;
-    const incomingChannel = `cca:chat:incoming:${namespace}`;
+    const notifyCh = notifyChannel(namespace);
+    const incomingCh = chatIncomingChannel(namespace);
 
-    if (channel === notifyChannel) {
+    if (channel === notifyCh) {
       const targetId = chatId ?? getActiveChatId?.();
       if (targetId != null) {
         const text = parseNotification(message);
@@ -314,7 +322,7 @@ export function startNotifier(
       return;
     }
 
-    if (channel === incomingChannel) {
+    if (channel === incomingCh) {
       let content = message;
       let originalTimestamp: string | undefined;
       try {
@@ -350,7 +358,7 @@ export function startNotifier(
         void (async () => {
           let routedToMetaAgent = false;
           try {
-            const statusRaw = await redis.get(`cca:meta-agent:status:${namespace}`);
+            const statusRaw = await redis.get(metaAgentStatusKey(namespace));
             if (statusRaw) {
               const status = JSON.parse(statusRaw) as { status?: string };
               if (status.status === "running") {
@@ -360,7 +368,7 @@ export function startNotifier(
                   timestamp: new Date().toISOString(),
                 });
                 // Polled by cc-agent every 3s — up to 3s delivery latency
-                await redis.rpush(`cca:meta:${namespace}:input`, entry);
+                await redis.rpush(metaInputKey(namespace), entry);
                 log("info", `cca:chat:incoming: routed to meta-agent for namespace ${namespace}`);
                 routedToMetaAgent = true;
               }

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,6 +11,7 @@
 
 import { execSync } from "child_process";
 import { Redis } from "ioredis";
+import { metaAgentStatusKey, metaKey, metaInputKey } from "@gonzih/cc-wire";
 
 /** Callback type matching CcTgBot.callCcAgentTool */
 export type CallToolFn = (toolName: string, args?: Record<string, unknown>) => Promise<string | null>;
@@ -91,9 +92,9 @@ export async function ensureMetaAgent(
   redis: Redis
 ): Promise<void> {
   const timeoutMs = parseInt(process.env.META_AGENT_TIMEOUT_MS ?? "10000", 10);
-  const statusKey = `cca:meta-agent:status:${namespace}`;
+  const statusKey = metaAgentStatusKey(namespace);
   // State key written by startMetaAgent() directly — the source of truth for workspace existence.
-  const stateKey = `cca:meta:${namespace}`;
+  const stateKey = metaKey(namespace);
 
   console.log(`[router] ensureMetaAgent namespace=${namespace}`);
 
@@ -217,6 +218,6 @@ export async function routeToMetaAgent(
     timestamp: new Date().toISOString(),
   });
   // FIFO — cc-agent reads via LPOP
-  await redis.rpush(`cca:meta:${namespace}:input`, entry);
+  await redis.rpush(metaInputKey(namespace), entry);
   console.log(`[router] routed message to meta-agent namespace=${namespace}`);
 }


### PR DESCRIPTION
## Summary

- Replaces all hardcoded Redis channel/key strings with imports from `@gonzih/cc-wire` (pure refactor — no behavior change). Migrated: `notifyChannel`, `chatLogKey`, `chatOutgoingChannel`, `chatIncomingChannel`, `metaAgentStatusKey`, `metaKey`, `metaInputKey`, `CC_TG_VERSION_KEY`, `VOICE_PENDING_KEY`, `VOICE_FAILED_KEY`, `TTL.VOICE_FAILED_SECONDS`
- Adds `←` prefix to meta-agent streaming responses in Telegram (`flushMetaAgentBuffer`) so users can visually distinguish meta-agent output from coordinator output

## Test plan

- [x] All 472 tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [x] `git diff --staged` reviewed — every change matches stated intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)