### PR TITLE
fix: forward cc-agent notifications only to active sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-tg",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "license": "MIT",
       "dependencies": {
         "@gonzih/agent-ops": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -641,6 +641,24 @@ export class CcTgBot {
     }
   }
 
+  /**
+   * Forward a cc-agent job notification into an existing Claude session.
+   * Unlike handleUserMessage, this never creates a new session — if no session
+   * is active for the chatId, the notification is already visible in Telegram
+   * and we silently skip feeding it into Claude.
+   */
+  public forwardNotification(chatId: number, text: string): void {
+    const key = this.sessionKey(chatId);
+    const session = this.sessions.get(key);
+    if (!session || session.claude.exited) return;
+    try {
+      session.claude.sendPrompt(stampPrompt(text));
+      this.writeChatMessage("user", "cc-tg", text, chatId);
+    } catch (err) {
+      console.error(`[forwardNotification:${chatId}] failed:`, (err as Error).message);
+    }
+  }
+
   private async handleVoice(chatId: number, msg: TelegramBot.Message, threadId?: number, threadName?: string): Promise<void> {
     const fileId = msg.voice?.file_id ?? msg.audio?.file_id;
     if (!fileId) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,7 @@ const notifyChatId = process.env.CC_AGENT_NOTIFY_CHAT_ID
 // Mutable placeholder closures — filled in once `bot` is created below.
 let getLastActiveChatIdFn: () => number | undefined = () => undefined;
 let handleUserMessageFn: ((chatId: number, text: string) => void) | undefined;
+let forwardNotificationFn: ((chatId: number, text: string) => void) | undefined;
 
 const notifierBot = new TelegramBot(telegramToken, { polling: false });
 const notifier = startNotifier(
@@ -166,6 +167,7 @@ const notifier = startNotifier(
   namespace,
   sharedRedis,
   (cid, text) => handleUserMessageFn?.(cid, text),
+  (cid, text) => forwardNotificationFn?.(cid, text),
   () => getLastActiveChatIdFn(),
 );
 console.log(`[notifier] started for namespace=${namespace} chatId=${notifyChatId ?? "dynamic"}`);
@@ -184,6 +186,7 @@ const bot = new CcTgBot({
 // Wire closures now that bot is constructed
 getLastActiveChatIdFn = () => bot.getLastActiveChatId();
 handleUserMessageFn = (cid, text) => { void bot.handleUserMessage(cid, text); };
+forwardNotificationFn = (cid, text) => { bot.forwardNotification(cid, text); };
 
 if (process.env.CC_AGENT_OPS_PORT) {
   const botInfo = await bot.getMe();

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -249,7 +249,7 @@ describe("startNotifier", () => {
       }
     });
 
-    startNotifier(bot as never, null, "dyn", redis as never, handleUserMessage, getActiveChatId);
+    startNotifier(bot as never, null, "dyn", redis as never, handleUserMessage, undefined, getActiveChatId);
 
     messageHandler!("cca:chat:incoming:dyn", "hello dynamic");
 
@@ -371,12 +371,58 @@ describe("startNotifier", () => {
       }
     });
 
-    startNotifier(bot as never, null, "dyn", redis as never, handleUserMessage, getActiveChatId);
+    startNotifier(bot as never, null, "dyn", redis as never, handleUserMessage, undefined, getActiveChatId);
 
     messageHandler!("cca:chat:incoming:dyn", "orphaned message");
 
     expect(bot.sendMessage).not.toHaveBeenCalled();
     expect(handleUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("forwardNotification is called for notify pub/sub, handleUserMessage is NOT called", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+    const forwardNotification = vi.fn();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 500, "testns", redis as never, handleUserMessage, forwardNotification);
+
+    messageHandler!("cca:notify:testns", "job finished");
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(500, "job finished");
+    expect(forwardNotification).toHaveBeenCalledWith(500, "job finished");
+    expect(handleUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("handleUserMessage is still called for cca:chat:incoming (unchanged)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+    const forwardNotification = vi.fn();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 600, "testns2", redis as never, handleUserMessage, forwardNotification);
+
+    messageHandler!("cca:chat:incoming:testns2", "hello from UI");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(600, "📱 [from UI]: hello from UI");
+    expect(handleUserMessage).toHaveBeenCalledWith(600, "hello from UI");
+    expect(forwardNotification).not.toHaveBeenCalled();
   });
 });
 
@@ -520,7 +566,7 @@ describe("meta-agent outgoing (pmessage)", () => {
     const getActiveChatId = vi.fn().mockReturnValue(77);
     const pmessage = capturePmessageHandler();
 
-    startNotifier(bot as never, null, "ns", redis as never, undefined, getActiveChatId);
+    startNotifier(bot as never, null, "ns", redis as never, undefined, undefined, getActiveChatId);
 
     pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
       JSON.stringify({ source: "claude", content: "dynamic chat" }));
@@ -536,7 +582,7 @@ describe("meta-agent outgoing (pmessage)", () => {
     const getActiveChatId = vi.fn().mockReturnValue(undefined);
     const pmessage = capturePmessageHandler();
 
-    startNotifier(bot as never, null, "ns", redis as never, undefined, getActiveChatId);
+    startNotifier(bot as never, null, "ns", redis as never, undefined, undefined, getActiveChatId);
 
     pmessage("cca:chat:outgoing:*", "cca:chat:outgoing:ns",
       JSON.stringify({ source: "claude", content: "orphaned" }));
@@ -637,7 +683,7 @@ describe("meta-agent outgoing (pmessage)", () => {
       const getActiveChatId = vi.fn().mockReturnValue(555);
       const pmessage = capturePmessageHandler();
 
-      const notifier = startNotifier(bot as never, null, "money-brain", redis as never, undefined, getActiveChatId);
+      const notifier = startNotifier(bot as never, null, "money-brain", redis as never, undefined, undefined, getActiveChatId);
       // Register for a different namespace — of-stack not registered
       notifier.registerRoutedChatId("other-ns", 999);
 
@@ -784,7 +830,7 @@ describe("notify list poller", () => {
 
     mockRpop.mockResolvedValueOnce(JSON.stringify({ text: "hello" })).mockResolvedValue(null);
 
-    startNotifier(bot as never, null, "ns-noid", redis as never, undefined, () => undefined);
+    startNotifier(bot as never, null, "ns-noid", redis as never, undefined, undefined, () => undefined);
 
     await vi.advanceTimersByTimeAsync(5_000);
 
@@ -799,32 +845,34 @@ describe("notify list poller", () => {
       .mockResolvedValueOnce(JSON.stringify({ text: "dynamic notify" }))
       .mockResolvedValue(null);
 
-    startNotifier(bot as never, null, "ns-dynamic", redis as never, undefined, () => 42);
+    startNotifier(bot as never, null, "ns-dynamic", redis as never, undefined, undefined, () => 42);
 
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(bot.sendMessage).toHaveBeenCalledWith(42, "dynamic notify");
   });
 
-  it("calls handleUserMessage for each polled notify item", async () => {
+  it("calls forwardNotification (not handleUserMessage) for each polled notify item", async () => {
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
+    const forwardNotification = vi.fn();
 
     mockRpop
       .mockResolvedValueOnce(JSON.stringify({ text: "Task complete" }))
       .mockResolvedValueOnce(JSON.stringify({ text: "Another job done" }))
       .mockResolvedValue(null);
 
-    startNotifier(bot as never, 555, "ns-hum", redis as never, handleUserMessage);
+    startNotifier(bot as never, 555, "ns-hum", redis as never, handleUserMessage, forwardNotification);
 
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(bot.sendMessage).toHaveBeenCalledWith(555, "Task complete");
     expect(bot.sendMessage).toHaveBeenCalledWith(555, "Another job done");
-    expect(handleUserMessage).toHaveBeenCalledWith(555, "Task complete");
-    expect(handleUserMessage).toHaveBeenCalledWith(555, "Another job done");
-    expect(handleUserMessage).toHaveBeenCalledTimes(2);
+    expect(forwardNotification).toHaveBeenCalledWith(555, "Task complete");
+    expect(forwardNotification).toHaveBeenCalledWith(555, "Another job done");
+    expect(forwardNotification).toHaveBeenCalledTimes(2);
+    expect(handleUserMessage).not.toHaveBeenCalled();
   });
 
   it("does not call handleUserMessage when it is undefined (poll path)", async () => {
@@ -853,6 +901,21 @@ describe("notify list poller", () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not call forwardNotification when it is undefined (poll path)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "Silent notify" }))
+      .mockResolvedValue(null);
+
+    // No forwardNotification — should not throw
+    startNotifier(bot as never, 555, "ns-nofwd", redis as never);
+
+    await expect(vi.advanceTimersByTimeAsync(5_000)).resolves.not.toThrow();
+    expect(bot.sendMessage).toHaveBeenCalledWith(555, "Silent notify");
   });
 });
 
@@ -926,10 +989,11 @@ describe("parseNotification", () => {
     expect(parseNotification(JSON.stringify({ foo: "bar" }))).toBe(JSON.stringify({ foo: "bar" }));
   });
 
-  it("pub/sub handler calls handleUserMessage with same text sent to Telegram", () => {
+  it("pub/sub handler calls forwardNotification (not handleUserMessage) with same text sent to Telegram", () => {
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
+    const forwardNotification = vi.fn();
 
     let messageHandler: ((channel: string, message: string) => void) | undefined;
     mockOn.mockImplementation((event: string, handler: unknown) => {
@@ -938,11 +1002,12 @@ describe("parseNotification", () => {
       }
     });
 
-    startNotifier(bot as never, 456, "myns", redis as never, handleUserMessage);
+    startNotifier(bot as never, 456, "myns", redis as never, handleUserMessage, forwardNotification);
 
     messageHandler!("cca:notify:myns", "Job done: my-task");
     expect(bot.sendMessage).toHaveBeenCalledWith(456, "Job done: my-task");
-    expect(handleUserMessage).toHaveBeenCalledWith(456, "Job done: my-task");
+    expect(forwardNotification).toHaveBeenCalledWith(456, "Job done: my-task");
+    expect(handleUserMessage).not.toHaveBeenCalled();
   });
 
   it("pub/sub handler does not call handleUserMessage when it is undefined", () => {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -133,8 +133,9 @@ export interface NotifierHandle {
  * @param chatId    - Telegram chat ID to forward notifications to. Pass null to use getActiveChatId.
  * @param namespace - cc-agent namespace (used to build Redis channel names)
  * @param redis     - ioredis client in normal mode (will be duplicated for pub/sub)
- * @param handleUserMessage - Optional callback to feed UI messages into the active Claude session
- * @param getActiveChatId   - Optional callback to resolve chatId dynamically (used when chatId is null)
+ * @param handleUserMessage    - Optional callback to feed UI messages into the active Claude session
+ * @param forwardNotification  - Optional callback to forward job notifications to an existing Claude session only (no session creation)
+ * @param getActiveChatId      - Optional callback to resolve chatId dynamically (used when chatId is null)
  *
  * @returns NotifierHandle with registerRoutedChatId for per-namespace response routing
  */
@@ -144,6 +145,7 @@ export function startNotifier(
   namespace: string,
   redis: Redis,
   handleUserMessage?: (chatId: number, text: string) => void,
+  forwardNotification?: (chatId: number, text: string) => void,
   getActiveChatId?: () => number | undefined
 ): NotifierHandle {
   // Per-namespace chatId registry: when a message is routed to a non-default namespace,
@@ -286,8 +288,8 @@ export function startNotifier(
       bot.sendMessage(targetId, text).catch((err: Error) => {
         log("warn", "notify list sendMessage failed:", err.message);
       });
-      if (handleUserMessage) {
-        handleUserMessage(targetId, text);
+      if (forwardNotification) {
+        forwardNotification(targetId, text);
       }
     }
 
@@ -313,8 +315,8 @@ export function startNotifier(
         bot.sendMessage(targetId, text).catch((err: Error) => {
           log("warn", "sendMessage failed:", err.message);
         });
-        if (handleUserMessage) {
-          handleUserMessage(targetId, text);
+        if (forwardNotification) {
+          forwardNotification(targetId, text);
         }
       } else {
         log("warn", "notify: no chatId available, dropping notification");


### PR DESCRIPTION
## Summary

- Notifications arriving via `cca:notify:{ns}` previously called `handleUserMessage`, which created an orphaned Claude session when none was active
- The orphaned session processed the notification in isolation and its conversation never reached the coordinator Claude
- Fix: add `forwardNotification` callback to `startNotifier` (6th positional param) and a corresponding `CcTgBot.forwardNotification` method that only sends to an already-running session — silently skips when no session is active (notification is already visible in Telegram)
- `handleUserMessage` remains wired to `cca:chat:incoming` (UI messages) unchanged

## Test plan

- [x] All 475 tests pass
- [x] New test: `forwardNotification` is called for notify pub/sub, `handleUserMessage` is NOT called
- [x] New test: `forwardNotification` is called for each polled notify item
- [x] New test: `handleUserMessage` is still called for `cca:chat:incoming` (unchanged)
- [x] Updated existing tests that checked `handleUserMessage` for notify channel to use `forwardNotification`
- [x] Build passes clean (`tsc && chmod +x dist/index.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)