### PR TITLE
test: comprehensive unit tests for utility/helper modules

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,51 +1,71 @@
-# Plan: Hashtag Meta-Agent Routing
+# Plan: Comprehensive Unit Tests for Utility Modules
 
 ## Task restatement
 
-When a Telegram user sends a message containing `#tag` or `#org/repo`, route it to the
-corresponding cc-agent meta-agent instead of the local Claude session. Auto-create the
-GitHub repo and start the meta-agent if not already running. Reply immediately with
-`→ #namespace` so the user knows the message was delegated.
+Add tests for uncovered code paths, error handling, boundary conditions, and all conditional
+branches in the utility/helper/library modules: formatter.ts, tokens.ts, usage-limit.ts,
+cron.ts, router.ts, voice.ts, and seed.ts.
 
-## Approach options
+## Approach
 
-### A. Redis-only approach
-Skip MCP tools entirely. Check `cca:meta-agent:status:{namespace}` directly, use `spawn_agent`
-MCP tool to start, RPUSH to `cca:meta:{namespace}:input` to send.
-- Pro: Known working tools, consistent with notifier.ts patterns
-- Con: `spawn_agent` requires a `task` string — unclear what task makes a "meta-agent"
+Add tests directly to the existing test files — no new files needed. Each file already
+has a consistent vi/vitest style to follow.
 
-### B. MCP tool approach (spec-faithful)
-Call `start_meta_agent` and `message_meta_agent` via `callCcAgentTool`, check status via Redis.
-- Pro: Follows task spec, clean separation of concerns
-- Con: These tools may not exist in current cc-agent, returns null on failure
+## Key gaps to cover
 
-### C. Hybrid (chosen)
-- Check Redis for `cca:meta-agent:status:{namespace}` directly (known-working pattern from notifier.ts)
-- Call `callCcAgentTool("start_meta_agent", {namespace, repo_url})` to start — throw on null
-- Route messages via Redis RPUSH to `cca:meta:{namespace}:input` (known-working pattern)
-- Use `execSync` for `gh` repo verification/creation (same pattern as bot.ts)
+### formatter.ts
+- `htmlEscape()` directly (never called in isolation)
+- `splitLongMessage` with a `<pre>` block covering the only split point → `coveringPre` branch
+- `formatForTelegram` with `---` mid-sentence (should NOT convert)
+- `formatForTelegram` with bold spanning newlines (`s` flag)
+- `splitLongMessage` empty remaining after loop → no trailing chunk
 
-**Why this:** Stays consistent with existing code patterns, is spec-faithful for the start mechanism,
-and uses the reliable Redis RPUSH that notifier.ts already does for routing.
+### tokens.ts
+- Empty string `CLAUDE_CODE_OAUTH_TOKENS=""` → empty array (split+filter)
+- Whitespace-only tokens `"  ,  "` → filtered to []
+- Lazy init via `getCurrentToken` without prior `loadTokens`
+
+### usage-limit.ts
+- Text with both usage AND rate_limit keywords → usage_exhausted wins
+- `detected:false` branch → reason/retryAfterMs/humanMessage defaults
+
+### cron.ts
+- `clearAll` when no jobs → does NOT call persist (count=0 branch)
+- `load()` with corrupted JSON → logs error, doesn't crash
+- `load()` with valid persisted jobs → restores and schedules them
+- `update` with empty `{}` (no-op update) → still recreates timer
+
+### router.ts
+- `parseRoutingTag` with `#-repo` (dash start → no match)
+- `ensureMetaAgent` with corrupted status JSON → falls through
+- `ensureMetaAgent` with corrupted state JSON → falls through
+- `ensureMetaAgent` with `ok:false` no `error` field → "unknown error"
+- `ensureMetaAgent` when `gh repo create` throws → propagates error
+- `routeToMetaAgent` with single-word message (happy path edge)
+
+### voice.ts
+- HTTP URL (not HTTPS) → uses http getter
+- Request-level network error → rejects
+- Non-`.en.` model → uses `-l auto`
+- Only whitespace after artifact removal → `[empty transcription]`
+
+### seed.ts
+- `console.log` is called when file is written
+- Error from `writeFileSync` propagates
 
 ## Files to touch
 
-- `src/router.ts` — new: parseRoutingTag, ensureMetaAgent, routeToMetaAgent
-- `src/router.test.ts` — new: unit tests
-- `src/bot.ts` — add routing check in handleTelegram() before getOrCreateSession()
+- src/formatter.test.ts
+- src/tokens.test.ts
+- src/usage-limit.test.ts
+- src/cron.test.ts
+- src/router.test.ts
+- src/voice.test.ts
+- src/seed.test.ts
 
 ## Risks
 
-- `start_meta_agent` MCP tool may not exist → error surfaced to user with clear message
-- `gh` CLI may not be installed in the runtime environment → execSync throws, caught and re-thrown
-- strippedMessage may be empty if user sends only `#tag` → routeToMetaAgent is skipped, ensureMetaAgent still runs
-- Regex `#org/repo` might greedily match inside URLs → acceptable; Telegram plain text rarely embeds bare URLs with hash routing syntax
-
-## Key decisions
-
-- Tag parsed anywhere in message (not just start), first match wins
-- Strip tag + normalize whitespace before forwarding
-- If Redis not configured, skip routing entirely (fall through to local Claude)
-- Route BEFORE getOrCreateSession (skips local Claude session entirely)
-- Log the user message to chat log as "user"/"telegram" before routing
+- cron `load()` test requires mocking `existsSync` to return true + `readFileSync` to return JSON;
+  the module-level mock already does this but needs per-test overrides
+- voice http mock requires adding http mock setup (current tests only use https)
+- formatter `htmlEscape` is not exported — must test via `formatForTelegram` proxy

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,13 @@
-# TODO: Protocol Compliance Audit
+# TODO: Comprehensive Unit Tests
 
-- [x] Read all relevant source files and audit against protocol spec
-- [x] Write PLAN.md and TODO.md
-- [ ] Create branch fix/protocol-compliance
-- [ ] Fix ChatMessage id to use crypto.randomUUID() in bot.ts and notifier.ts
-- [ ] Add LIFO ordering comment to writeChatLog() LPUSH in notifier.ts
-- [ ] Fix meta-agent input queue: lpush → rpush + add timing comment in notifier.ts
-- [ ] Add descriptive comment to FLUSH_DELAY_MS in bot.ts
-- [ ] Extract 1500ms to META_AGENT_FLUSH_DELAY_MS constant + add comment in notifier.ts
-- [ ] Add token rotation independence comment to tokens.ts
-- [ ] Create docs/redis-protocol.md
-- [ ] Run build, verify it passes
+- [ ] Create branch feat/comprehensive-unit-tests
+- [ ] Add tests to formatter.test.ts
+- [ ] Add tests to tokens.test.ts
+- [ ] Add tests to usage-limit.test.ts
+- [ ] Add tests to cron.test.ts
+- [ ] Add tests to router.test.ts
+- [ ] Add tests to voice.test.ts
+- [ ] Add tests to seed.test.ts
+- [ ] Run npm test — verify all pass
+- [ ] git diff --staged review
 - [ ] Commit, push, PR, merge, publish

--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -11,7 +11,12 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { CronManager, type CronJob } from './cron.js';
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
 
 describe('CronManager.parseSchedule', () => {
   it('parses minutes', () => {
@@ -231,5 +236,112 @@ describe('CronManager operations', () => {
       vi.advanceTimersByTime(120_000);
       expect(fireCallback).toHaveBeenCalledWith(42, 'new prompt', expect.any(String), expect.any(Function));
     });
+
+    it('no-op update (empty updates object) recreates timer with original values', () => {
+      fireCallback.mockImplementation((_chatId, _prompt, _jobId, done) => done());
+      const job = manager.add(42, 'every 1m', 'my prompt')!;
+      const updated = manager.update(42, job.id, {}) as CronJob;
+      expect(updated).not.toBe(false);
+      expect(updated).not.toBeNull();
+      expect(updated.prompt).toBe('my prompt');
+      expect(updated.schedule).toBe('every 1m');
+      // Timer still fires
+      vi.advanceTimersByTime(60_000);
+      expect(fireCallback).toHaveBeenCalledWith(42, 'my prompt', expect.any(String), expect.any(Function));
+    });
+  });
+
+  describe('clearAll — persist behavior', () => {
+    it('does not call persist when there are no jobs to clear (count === 0 branch)', () => {
+      mockWriteFileSync.mockClear();
+      const count = manager.clearAll(42);
+      expect(count).toBe(0);
+      // persist() is only called when count > 0
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('CronManager — load() behavior', () => {
+  let fireCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fireCallback = vi.fn();
+    // Reset mocks to defaults
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue('[]');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('skips loading when crons.json does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const manager = new CronManager('/tmp/no-file', fireCallback);
+    expect(manager.list(42)).toEqual([]);
+  });
+
+  it('restores jobs from disk and schedules their timers', () => {
+    const storedJob: CronJob = {
+      id: 'test-id',
+      chatId: 42,
+      intervalMs: 60_000,
+      prompt: 'loaded prompt',
+      schedule: 'every 1m',
+      createdAt: new Date().toISOString(),
+    };
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify([storedJob]));
+    fireCallback.mockImplementation((_chatId, _prompt, _jobId, done) => done());
+
+    const manager = new CronManager('/tmp/has-file', fireCallback);
+    expect(manager.list(42)).toHaveLength(1);
+    expect(manager.list(42)[0].prompt).toBe('loaded prompt');
+
+    // Timer should fire
+    vi.advanceTimersByTime(60_000);
+    expect(fireCallback).toHaveBeenCalledWith(42, 'loaded prompt', 'test-id', expect.any(Function));
+
+    // Cleanup
+    manager.clearAll(42);
+  });
+
+  it('gracefully handles corrupted JSON in crons.json', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{ not valid json ');
+
+    // Should not throw — just logs error
+    expect(() => new CronManager('/tmp/corrupt', fireCallback)).not.toThrow();
+  });
+
+  it('handles persist errors gracefully (writeFileSync throws)', () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => { throw new Error('EACCES: permission denied'); });
+
+    // add() calls persist() — should not throw even when persist fails
+    const manager = new CronManager('/tmp/no-write', fireCallback);
+    expect(() => manager.add(42, 'every 1m', 'test')).not.toThrow();
+  });
+});
+
+describe('CronManager.parseSchedule — additional edge cases', () => {
+  it('trims leading and trailing whitespace before matching', () => {
+    expect(CronManager.parseSchedule('  every 5m  ')).toBe(5 * 60_000);
+    expect(CronManager.parseSchedule('\tevery 2h\t')).toBe(2 * 3_600_000);
+  });
+
+  it('returns null for zero interval (0m)', () => {
+    // parseSchedule returns 0 for "every 0m" which is falsy — add() treats it as null
+    const ms = CronManager.parseSchedule('every 0m');
+    // 0 is falsy, so add() returns null for it
+    expect(ms).toBe(0);
+  });
+
+  it('returns null for non-digit schedule values', () => {
+    expect(CronManager.parseSchedule('every xh')).toBeNull();
+    expect(CronManager.parseSchedule('every 1.5h')).toBeNull();
   });
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { formatForTelegram, splitLongMessage } from "./formatter.js";
 
+// htmlEscape is not exported but we can verify it through formatForTelegram
+// by passing text that contains HTML special chars outside code blocks.
+
 describe("formatForTelegram", () => {
   describe("headings → bold", () => {
     it("converts ## heading to <b>bold</b>", () => {
@@ -304,5 +307,95 @@ describe("splitLongMessage", () => {
       const closes = (chunk.match(/<\/pre>/g) || []).length;
       expect(opens).toBe(closes);
     }
+  });
+
+  it("splits after a covering <pre> block when all natural boundaries are inside it", () => {
+    // Construct text: a <pre> block that spans maxLen boundary, with no spaces or newlines
+    // outside it within the window — forces the coveringPre branch.
+    const preContent = "y".repeat(2000);
+    const text = `<pre>${preContent}</pre>extra`;
+    // maxLen=100 — the pre block spans [0, 2011], which covers position 100.
+    // No spaces/newlines inside the pre block, so coveringPre branch must fire.
+    const chunks = splitLongMessage(text, 100);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    // The first chunk must end at the close of the <pre> block
+    expect(chunks[0]).toContain("</pre>");
+    // No chunk should have mismatched <pre>/<\/pre> tags
+    for (const chunk of chunks) {
+      const opens = (chunk.match(/<pre>/g) || []).length;
+      const closes = (chunk.match(/<\/pre>/g) || []).length;
+      expect(opens).toBe(closes);
+    }
+  });
+
+  it("hard-splits at maxLen when no boundary and no covering pre block", () => {
+    // Pure run of 'a' with no spaces/newlines/pre — falls to splitAt = maxLen
+    const text = "a".repeat(200);
+    const chunks = splitLongMessage(text, 50);
+    // Every chunk should be at most 50 characters
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(50);
+    }
+    // Content is fully preserved
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("produces no trailing empty chunk when remaining is exactly empty after loop", () => {
+    // text length = 2 * maxLen exactly, split at word boundary at maxLen
+    // After slicing off the first half, remaining is exactly the second half with no leftover.
+    const half = "a".repeat(50);
+    const text = `${half} ${half}`;  // 101 chars with space at index 50
+    const chunks = splitLongMessage(text, 51);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("formatForTelegram — additional edge cases", () => {
+  it("--- in the middle of a sentence is NOT converted (only full-line ---)", () => {
+    // The regex ^-{3,}$ with gm only matches --- on its own line
+    const result = formatForTelegram("before --- after");
+    expect(result).toBe("before --- after");
+  });
+
+  it("longer rule (----) on its own line is also stripped", () => {
+    const result = formatForTelegram("above\n----\nbelow");
+    expect(result).toBe("above\n\nbelow");
+  });
+
+  it("bold spanning a newline is converted (s flag)", () => {
+    const result = formatForTelegram("**hello\nworld**");
+    expect(result).toBe("<b>hello\nworld</b>");
+  });
+
+  it("multiple HTML special chars in the same text", () => {
+    // & < > all in one string
+    const result = formatForTelegram("a & b < c > d");
+    expect(result).toBe("a &amp; b &lt; c &gt; d");
+  });
+
+  it("htmlEscape inside code block does not double-escape", () => {
+    // <pre> content is html-escaped once; the outer text is also html-escaped
+    const input = "```\na & b\n```";
+    const result = formatForTelegram(input);
+    expect(result).toBe("<pre>a &amp; b\n</pre>");
+  });
+
+  it("italic does not fire for snake_case in the middle of a word", () => {
+    expect(formatForTelegram("foo_bar_baz")).toBe("foo_bar_baz");
+  });
+
+  it("italic fires when _ delimiters are at non-word-character boundaries", () => {
+    expect(formatForTelegram("(_italic_)")).toBe("(<i>italic</i>)");
+  });
+
+  it("inline code with < and > escapes them", () => {
+    const result = formatForTelegram("`a < b`");
+    expect(result).toBe("<code>a &lt; b</code>");
+  });
+
+  it("handles empty string input", () => {
+    expect(formatForTelegram("")).toBe("");
   });
 });

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -111,6 +111,32 @@ describe("parseRoutingTag", () => {
   it("returns null for bare # with no following word char", () => {
     expect(parseRoutingTag("hello # world")).toBeNull();
   });
+
+  it("returns null when tag starts with a dash (#-repo is invalid)", () => {
+    // Regex requires [a-zA-Z0-9] as first char after #
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    expect(parseRoutingTag("#-repo fix it")).toBeNull();
+  });
+
+  it("handles repo name with dots and underscores (#org/my_repo.v2)", () => {
+    const result = parseRoutingTag("#gonzih/my_repo.v2 deploy");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("my_repo.v2");
+    expect(result!.repoUrl).toBe("https://github.com/gonzih/my_repo.v2");
+  });
+
+  it("tag-only message results in empty strippedMessage for #org/repo", () => {
+    const result = parseRoutingTag("#gonzih/cc-agent");
+    expect(result).not.toBeNull();
+    expect(result!.strippedMessage).toBe("");
+  });
+
+  it("strips tag from end of message", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    const result = parseRoutingTag("fix the bug #cc-agent");
+    expect(result).not.toBeNull();
+    expect(result!.strippedMessage).toBe("fix the bug");
+  });
 });
 
 // ===========================================================================
@@ -335,5 +361,128 @@ describe("ensureMetaAgent", () => {
     await expect(
       ensureMetaAgent("of-stack", "https://github.com/gonzih/of-stack", callTool, redis)
     ).rejects.toThrow("start_meta_agent failed: git clone failed: repository not found");
+  });
+
+  it("throws 'unknown error' when ok:false payload has no error field", async () => {
+    mockGet.mockResolvedValueOnce(null);
+    mockGet.mockResolvedValueOnce(null);
+    mockExecSync.mockReturnValue("");
+
+    const callTool = vi.fn().mockResolvedValue(JSON.stringify({ ok: false }));
+    const redis = makeRedis();
+
+    await expect(
+      ensureMetaAgent("ns", "https://github.com/gonzih/ns", callTool, redis)
+    ).rejects.toThrow("start_meta_agent failed: unknown error");
+  });
+
+  it("falls through corrupted status JSON and continues to state key check", async () => {
+    // Status key has corrupted JSON → falls through to stateKey
+    mockGet.mockResolvedValueOnce("{not valid json}"); // corrupted status key
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: "idle" }));  // state key has idle
+
+    const callTool = vi.fn();
+    const redis = makeRedis();
+
+    await ensureMetaAgent("ns", "https://github.com/gonzih/ns", callTool, redis);
+
+    // Should not have started the meta-agent (state key was idle)
+    expect(callTool).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("falls through corrupted state JSON and proceeds to start meta-agent", async () => {
+    // Both fast-path keys have corrupted JSON → must start fresh
+    mockGet.mockResolvedValueOnce("{bad}");   // corrupted status key
+    mockGet.mockResolvedValueOnce("{bad}");   // corrupted state key
+    // Poll: returns running on first tick
+    mockGet.mockResolvedValue(JSON.stringify({ status: "running" }));
+
+    mockExecSync.mockReturnValue("");
+    const callTool = vi.fn().mockResolvedValue("ok");
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("ns", "https://github.com/gonzih/ns", callTool, redis);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(callTool).toHaveBeenCalledWith("start_meta_agent", expect.objectContaining({ namespace: "ns" }));
+  });
+
+  it("throws when gh repo create fails", async () => {
+    mockGet.mockResolvedValueOnce(null);
+    mockGet.mockResolvedValueOnce(null);
+
+    // gh repo view throws (not found), gh repo create also throws
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error("not found"); })
+      .mockImplementationOnce(() => { throw new Error("already exists remotely"); });
+
+    const callTool = vi.fn();
+    const redis = makeRedis();
+
+    await expect(
+      ensureMetaAgent("ns", "https://github.com/gonzih/ns", callTool, redis)
+    ).rejects.toThrow("Failed to create repo gonzih/ns");
+  });
+
+  it("non-JSON plain text result from start_meta_agent does not throw", async () => {
+    // Fast path: both keys absent
+    mockGet.mockResolvedValueOnce(null);
+    mockGet.mockResolvedValueOnce(null);
+    // Poll: idle on first tick
+    mockGet.mockResolvedValue(JSON.stringify({ status: "idle" }));
+
+    mockExecSync.mockReturnValue("");
+    // Plain text (SyntaxError) — should not throw, continue to poll
+    const callTool = vi.fn().mockResolvedValue("ok");
+    const redis = makeRedis();
+
+    process.env.META_AGENT_TIMEOUT_MS = "5000";
+    vi.useFakeTimers();
+
+    const promise = ensureMetaAgent("ns", "https://github.com/gonzih/ns", callTool, redis);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+});
+
+// ===========================================================================
+// routeToMetaAgent — additional edge cases
+// ===========================================================================
+
+describe("routeToMetaAgent — additional cases", () => {
+  it("routes single-word stripped message", async () => {
+    mockRpush.mockResolvedValue(1);
+    const redis = makeRedis();
+
+    await routeToMetaAgent("ns", "deploy", redis);
+
+    expect(mockRpush).toHaveBeenCalledOnce();
+    const [key, raw] = mockRpush.mock.calls[0] as [string, string];
+    expect(key).toBe("cca:meta:ns:input");
+    const entry = JSON.parse(raw) as { content: string; id: string; timestamp: string };
+    expect(entry.content).toBe("deploy");
+  });
+
+  it("does not route whitespace-only stripped message (empty after trim)", async () => {
+    const redis = makeRedis();
+    // The function only checks `if (!strippedMessage)` — empty string is falsy
+    await routeToMetaAgent("ns", "", redis);
+    expect(mockRpush).not.toHaveBeenCalled();
+  });
+
+  it("timestamp in routed entry is a valid ISO 8601 string", async () => {
+    mockRpush.mockResolvedValue(1);
+    const redis = makeRedis();
+    await routeToMetaAgent("ns", "hello", redis);
+    const raw = (mockRpush.mock.calls[0] as [string, string])[1];
+    const entry = JSON.parse(raw) as { timestamp: string };
+    expect(() => new Date(entry.timestamp).toISOString()).not.toThrow();
   });
 });

--- a/src/seed.test.ts
+++ b/src/seed.test.ts
@@ -15,6 +15,9 @@ const mockWriteFileSync = vi.mocked(writeFileSync);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset implementations so error-injecting tests don't bleed into subsequent tests
+  mockMkdirSync.mockImplementation(() => undefined);
+  mockWriteFileSync.mockImplementation(() => undefined);
 });
 
 describe("seedClaudeMd", () => {
@@ -57,5 +60,47 @@ describe("seedClaudeMd", () => {
     expect(content).toContain("FERAL LIFE Protocol");
     expect(content).toContain("AXIOM");
     expect(content).toContain("Void Operator");
+  });
+
+  it("logs confirmation message after writing", () => {
+    mockExistsSync.mockReturnValue(false);
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    seedClaudeMd("/some/project");
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("seeded .claude/CLAUDE.md")
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("does not log when file already exists", () => {
+    mockExistsSync.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    seedClaudeMd("/some/project");
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("propagates writeFileSync errors", () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => { throw new Error("EACCES: permission denied"); });
+
+    expect(() => seedClaudeMd("/some/project")).toThrow("EACCES: permission denied");
+  });
+
+  it("propagates mkdirSync errors", () => {
+    mockExistsSync.mockReturnValue(false);
+    mockMkdirSync.mockImplementation(() => { throw new Error("ENOTDIR"); });
+
+    expect(() => seedClaudeMd("/some/project")).toThrow("ENOTDIR");
+  });
+
+  it("uses correct encoding (utf-8) when writing", () => {
+    mockExistsSync.mockReturnValue(false);
+    seedClaudeMd("/some/project");
+    expect(mockWriteFileSync.mock.calls[0][2]).toBe("utf-8");
   });
 });

--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -219,3 +219,49 @@ describe("all-exhausted detection", () => {
     );
   });
 });
+
+describe("edge cases — env var values", () => {
+  it("empty string CLAUDE_CODE_OAUTH_TOKENS results in empty pool", () => {
+    withEnv(
+      { CLAUDE_CODE_OAUTH_TOKENS: "", CLAUDE_CODE_OAUTH_TOKEN: undefined },
+      () => {
+        // empty string is falsy — falls through to CLAUDE_CODE_OAUTH_TOKEN branch
+        loadTokens();
+        expect(getTokenCount()).toBe(0);
+        expect(getCurrentToken()).toBe("");
+      }
+    );
+  });
+
+  it("whitespace-only tokens are filtered out", () => {
+    withEnv(
+      { CLAUDE_CODE_OAUTH_TOKENS: "  ,  ,  ", CLAUDE_CODE_OAUTH_TOKEN: undefined },
+      () => {
+        loadTokens();
+        expect(getTokenCount()).toBe(0);
+        expect(getCurrentToken()).toBe("");
+      }
+    );
+  });
+
+  it("mixed valid and whitespace tokens keeps only non-empty ones", () => {
+    withEnv(
+      { CLAUDE_CODE_OAUTH_TOKENS: "tok1,  , tok2 ,", CLAUDE_CODE_OAUTH_TOKEN: undefined },
+      () => {
+        loadTokens();
+        expect(getTokenCount()).toBe(2);
+        expect(getCurrentToken()).toBe("tok1");
+      }
+    );
+  });
+
+  it("getTokenIndex returns 0 when no tokens loaded", () => {
+    withEnv(
+      { CLAUDE_CODE_OAUTH_TOKENS: undefined, CLAUDE_CODE_OAUTH_TOKEN: undefined },
+      () => {
+        loadTokens();
+        expect(getTokenIndex()).toBe(0);
+      }
+    );
+  });
+});

--- a/src/usage-limit.test.ts
+++ b/src/usage-limit.test.ts
@@ -80,4 +80,43 @@ describe("detectUsageLimit", () => {
     const wakeDate = new Date("2026-03-22T11:05:00Z");
     expect(sig.humanMessage).toContain(wakeDate.toUTCString());
   });
+
+  it("usage_exhausted takes priority over rate_limit when both keywords present", () => {
+    // The usage check runs first in detectUsageLimit
+    const sig = detectUsageLimit("usage limit exceeded and rate limit also exceeded");
+    expect(sig.detected).toBe(true);
+    expect(sig.reason).toBe("usage_exhausted");
+  });
+
+  it("not-detected result has reason:rate_limit, retryAfterMs:0, humanMessage empty", () => {
+    const sig = detectUsageLimit("everything is fine");
+    expect(sig.detected).toBe(false);
+    expect(sig.reason).toBe("rate_limit");
+    expect(sig.retryAfterMs).toBe(0);
+    expect(sig.humanMessage).toBe("");
+  });
+
+  it("detects 'rate limit' case-insensitively", () => {
+    expect(detectUsageLimit("RATE LIMIT exceeded").reason).toBe("rate_limit");
+    expect(detectUsageLimit("Rate Limit hit").reason).toBe("rate_limit");
+  });
+
+  it("detects 'overloaded' case-insensitively", () => {
+    expect(detectUsageLimit("System is OVERLOADED").detected).toBe(true);
+    expect(detectUsageLimit("System is OVERLOADED").reason).toBe("rate_limit");
+  });
+
+  it("at exactly midnight (00:00:00) the wake time is next day 01:05", () => {
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const sig = detectUsageLimit("usage limit reached");
+    const wakeDate = new Date("2026-03-22T01:05:00Z");
+    expect(sig.humanMessage).toContain(wakeDate.toUTCString());
+  });
+
+  it("at 23:30 the wake time is next day 00:05", () => {
+    vi.setSystemTime(new Date("2026-03-22T23:30:00Z"));
+    const sig = detectUsageLimit("usage limit reached");
+    const wakeDate = new Date("2026-03-23T00:05:00Z");
+    expect(sig.humanMessage).toContain(wakeDate.toUTCString());
+  });
 });

--- a/src/voice.test.ts
+++ b/src/voice.test.ts
@@ -358,5 +358,123 @@ describe('transcribeVoice', () => {
         expect.any(Function),
       );
     });
+
+    it('uses http module for http:// URLs (not https)', async () => {
+      // Set up http download mock
+      const fileStream = makeWriteStream();
+      mocks.createWriteStreamMock.mockReturnValue(fileStream);
+
+      const mockHttpRequest = { on: vi.fn().mockReturnThis() };
+      mocks.httpGetMock.mockImplementation((_url: string, cb: (res: unknown) => void) => {
+        const res = {
+          statusCode: 200,
+          pipe: vi.fn((dest: ReturnType<typeof makeWriteStream>) => {
+            Promise.resolve().then(() => dest._emit('finish'));
+            return dest;
+          }),
+        };
+        cb(res);
+        return mockHttpRequest;
+      });
+
+      await transcribeVoice('http://example.com/voice.ogg');
+
+      expect(mocks.httpGetMock).toHaveBeenCalledWith(
+        'http://example.com/voice.ogg',
+        expect.any(Function),
+      );
+      expect(mocks.httpsGetMock).not.toHaveBeenCalled();
+    });
+
+    it('propagates network request-level errors', async () => {
+      const fileStream = makeWriteStream();
+      mocks.createWriteStreamMock.mockReturnValue(fileStream);
+
+      const mockRequest = {
+        on: vi.fn((event: string, cb: (err: Error) => void) => {
+          if (event === 'error') {
+            Promise.resolve().then(() => cb(new Error('ECONNREFUSED')));
+          }
+          return mockRequest;
+        }),
+      };
+      mocks.httpsGetMock.mockReturnValue(mockRequest);
+
+      await expect(transcribeVoice('https://example.com/voice.ogg'))
+        .rejects.toThrow('ECONNREFUSED');
+    });
+  });
+});
+
+describe('transcribeVoice — non-.en. model uses -l auto', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.unlinkMock.mockResolvedValue(undefined);
+    mocks.readFileMock.mockResolvedValue('transcribed');
+    mocks.execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+    // Make whisper available but use a non-.en. model (ggml-small.bin)
+    const WHISPER_PATH = '/opt/homebrew/bin/whisper-cli';
+    const FFMPEG_PATH  = '/opt/homebrew/bin/ffmpeg';
+    const NON_EN_MODEL = '/opt/homebrew/share/whisper-cpp/ggml-small.bin';
+
+    mocks.existsSyncMock.mockImplementation((p: string) => {
+      if (p === WHISPER_PATH) return true;
+      if (p === FFMPEG_PATH) return true;
+      if (p === NON_EN_MODEL) return true;
+      return false;
+    });
+  });
+
+  function setupHttpsDownloadLocal(statusCode = 200) {
+    const fileStream = makeWriteStream();
+    mocks.createWriteStreamMock.mockReturnValue(fileStream);
+    const mockRequest = { on: vi.fn().mockReturnThis() };
+    mocks.httpsGetMock.mockImplementation((_url: string, cb: (res: unknown) => void) => {
+      const res = {
+        statusCode,
+        pipe: vi.fn((dest: ReturnType<typeof makeWriteStream>) => {
+          if (statusCode === 200) Promise.resolve().then(() => dest._emit('finish'));
+          return dest;
+        }),
+      };
+      cb(res);
+      return mockRequest;
+    });
+    return fileStream;
+  }
+
+  it('uses -l auto for model without .en. in path', async () => {
+    setupHttpsDownloadLocal();
+    await transcribeVoice('https://example.com/voice.ogg');
+
+    const [, args] = mocks.execFileAsyncMock.mock.calls[1] as [string, string[]];
+    const lIdx = args.indexOf('-l');
+    expect(lIdx).toBeGreaterThan(-1);
+    expect(args[lIdx + 1]).toBe('auto');
+  });
+});
+
+describe('isVoiceAvailable — additional cases', () => {
+  beforeEach(() => {
+    mocks.existsSyncMock.mockReturnValue(false);
+  });
+
+  it('returns false when only model is missing (whisper and ffmpeg available)', () => {
+    mocks.existsSyncMock.mockImplementation((p: string) => {
+      if (p === '/opt/homebrew/bin/whisper-cli') return true;
+      if (p === '/opt/homebrew/bin/ffmpeg') return true;
+      return false;
+    });
+    expect(isVoiceAvailable()).toBe(false);
+  });
+
+  it('returns false when only ffmpeg is missing', () => {
+    mocks.existsSyncMock.mockImplementation((p: string) => {
+      if (p === '/opt/homebrew/bin/whisper-cli') return true;
+      if (p === '/opt/homebrew/share/whisper-cpp/ggml-small.en.bin') return true;
+      return false;
+    });
+    expect(isVoiceAvailable()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Covers 53 previously-untested code paths across 7 utility/helper modules
- Grows test suite from 475 → 528 tests (all passing)
- No production code changes — test files only

## Modules covered

| Module | Key gaps addressed |
|--------|-------------------|
| **formatter.ts** | `coveringPre` branch in `splitLongMessage`, hard-split fallback, `---` mid-sentence, bold spanning newlines (`s` flag), empty string |
| **tokens.ts** | Empty/whitespace-only `CLAUDE_CODE_OAUTH_TOKENS`, mixed valid+whitespace filtering |
| **usage-limit.ts** | Priority ordering (usage_exhausted wins over rate_limit), `detected:false` defaults, case-insensitive detection, boundary times |
| **cron.ts** | `load()` disk restore, corrupted JSON recovery, persist error handling, `clearAll` no-persist branch, empty-update no-op, `parseSchedule` whitespace handling |
| **router.ts** | Invalid tag chars (`#-repo`), corrupted Redis JSON fast paths, `ok:false` without error field, `gh repo create` failure, additional `routeToMetaAgent` cases |
| **voice.ts** | HTTP (not HTTPS) URLs, request-level network errors, non-`.en.` model uses `-l auto`, `isVoiceAvailable` partial-availability |
| **seed.ts** | `console.log` verification, `mkdirSync`/`writeFileSync` error propagation, encoding, mock isolation fix |

## Test plan

- [x] All 528 tests pass (`npx vitest run`)
- [x] Diff reviewed — only test files and PLAN/TODO docs changed
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)