### PR TITLE
test: cover listSkills error paths and extractText content fallback

### DIFF
--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -847,6 +847,30 @@ describe('listSkills', () => {
     readdirMock.mockRestore();
     readFileMock.mockRestore();
   });
+
+  it('returns error message when readdirSync throws', () => {
+    mocks.existsSyncMock.mockReturnValue(true);
+    const readdirMock = vi.spyOn(fsModule, 'readdirSync').mockImplementation(() => {
+      throw new Error('permission denied');
+    });
+    const result = listSkills();
+    expect(result).toBe('Could not read skills directory.');
+    readdirMock.mockRestore();
+  });
+
+  it('lists skill name without description when readFileSync throws for that file', () => {
+    mocks.existsSyncMock.mockReturnValue(true);
+    const readdirMock = vi.spyOn(fsModule, 'readdirSync').mockReturnValue(['broken.md', 'ok.md'] as any);
+    const readFileMock = vi.spyOn(fsModule, 'readFileSync').mockImplementation((path: any) => {
+      if (String(path).includes('broken.md')) throw new Error('read error');
+      return '---\nname: ok\ndescription: Works fine\n---\n';
+    });
+    const result = listSkills();
+    expect(result).toContain('/broken');
+    expect(result).toContain('/ok — Works fine');
+    readdirMock.mockRestore();
+    readFileMock.mockRestore();
+  });
 });
 
 describe('CcTgBot chat bridge', () => {

--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -79,4 +79,13 @@ describe('extractText', () => {
     };
     expect(extractText(msg)).toBe('');
   });
+
+  it('returns empty string when content is neither string nor array', () => {
+    const msg = {
+      type: 'assistant' as const,
+      payload: { message: { content: 42 } },
+      raw: {},
+    };
+    expect(extractText(msg)).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary

Adds 3 targeted tests covering previously untested error paths in two files:

- **bot.test.ts**: 2 new tests for `listSkills` error handling:
  - When `readdirSync` throws → returns `"Could not read skills directory."` (bot.ts line 1803)
  - When per-file `readFileSync` throws → lists skill name without description (bot.ts line 1818)

- **claude.test.ts**: 1 new test for `extractText` when `message.content` is neither string nor array (e.g. a number) → returns `""` (claude.ts line 229)

## Context

PRs #102 and #103 already covered most of the same areas this branch originally targeted. This PR contains only the 3 tests that were not yet covered by those PRs.

## Coverage improvement

- `bot.ts`: lines 1803 and 1818 now covered
- `claude.ts`: line 229 now covered
- Overall: 551 → 554 tests passing

## Test plan

- [x] `npm test` — all 554 tests pass
- [x] No production code changed — test-only additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)