### PR TITLE
feat: /effort, /compact, auto-compact, cost warnings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,54 +1,74 @@
-# Plan: Comprehensive Unit Tests for 90%+ Coverage
+# PLAN.md — feat/effort-control
 
-## Task restatement
+## Task Restatement
+Add effort level control (`/effort <level>`), manual context compaction (`/compact`),
+auto-compact after N messages (`CC_TG_AUTO_COMPACT_MESSAGES`), and a session cost warning
+(`CC_TG_COST_WARN_USD`) to the cc-tg Telegram bot. Also update `/help` and README.
 
-Write unit tests for all uncovered functions/branches in core business logic modules
-(bot.ts, claude.ts, formatter.ts, voice.ts, notifier.ts) to hit 90%+ coverage.
+---
 
-## Current coverage gaps
+## Approaches Considered
 
-| File | Stmts | Branch | Funcs | Key gaps |
-|---|---|---|---|---|
-| bot.ts | 68.53% | 65.19% | 49.65% | normalizeTopicNamespace, listSkills, enrichPromptWithUrls, buildPromptWithReplyContext |
-| claude.ts | 83.52% | 72.22% | 93.33% | ClaudeProcess constructor, drainBuffer, sendPrompt, kill, resolveClaude |
-| formatter.ts | 86.66% | 66.66% | 80% | findPreRanges unclosed pre, splitLongMessage hard split |
-| voice.ts | 100% | 86.95% | 75% | HTTP (not HTTPS) download, non-.en model (-l auto), non-Error throw wrap |
-| notifier.ts | 91.32% | 93.25% | 67.85% | Already well-tested via existing tests |
+### A) Forward slash commands verbatim to Claude subprocess stdin (CHOSEN)
+Forward `/effort high` and `/compact` to Claude via `session.claude.sendPrompt()`.
+**Pro**: Zero new abstractions; exactly what the spec says.
+**Con**: Relies on Claude Code's stream-json input layer processing slash commands.
 
-## Approach
+### B) Pass effort/compact as CLI flags on process spawn
+Kill existing session and re-spawn with `--effort high` flag.
+**Con**: Loses conversation history; ugly UX. Rejected.
 
-### New files
-1. `src/claude-process.test.ts` — Tests for `ClaudeProcess` class:
-   - Mock `child_process.spawn` to control stdout/stderr/exit/error events
-   - Test drainBuffer: JSON parsing, usage events (message_start/message_delta), non-JSON skip
-   - Test sendPrompt: throws when exited, writes to stdin
-   - Test sendImage: with and without caption
-   - Test kill: calls proc.kill()
-   - Test exited getter state
-   - Test resolveClaude: PATH resolution via existsSync mock
+### C) Custom JSON message type
+Add `{ type: "command", command: "effort", value: "high" }`.
+**Con**: Claude Code doesn't define such a type. Rejected.
 
-2. `src/bot-helpers.test.ts` — Tests for exported helper functions from bot.ts:
-   - `normalizeTopicNamespace`: all transformation rules
-   - `listSkills`: no dir, empty dir, read error, missing descriptions
-   - `enrichPromptWithUrls`: no URLs, skip jina.ai, fetch failures, multiple URLs
+---
 
-### Modified files  
-3. `src/voice.test.ts` — Add:
-   - HTTP (not HTTPS) download uses http.get
-   - Non-.en model path uses `-l auto`
-   - whisper error wrapping non-Error objects
+## Approach: A — forward via sendPrompt
 
-4. `src/formatter.test.ts` — Add:
-   - `findPreRanges` with unclosed `<pre>` tag (no match)
-   - `splitLongMessage` hard split at maxLen (no natural boundaries)
+---
 
-## Files to touch
-- src/claude-process.test.ts (new)
-- src/bot-helpers.test.ts (new)
-- src/voice.test.ts (modify)
-- src/formatter.test.ts (modify)
+## Files to Touch
+- `src/bot.ts` — core changes: commands, session fields, auto-compact, cost warning
+- `src/bot.test.ts` — tests for new features
+- `README.md` — document new commands and env vars
+
+---
+
+## Implementation Details
+
+### Session interface additions
+```
+messagesSinceCompact: number   // incremented per-response; reset on /compact
+costWarnSent: boolean           // true once cost threshold notification is sent
+```
+
+### BOT_COMMANDS additions
+```
+{ command: "effort", description: "Set effort level: low / medium / high / xhigh / max / auto" }
+{ command: "compact", description: "Compact context history to free tokens" }
+```
+
+### /effort handler
+- Validate level in Set(["low","medium","high","xhigh","max","auto"])
+- No active session → informational reply
+- Active session → sendPrompt("/effort ${level}") + ack
+
+### /compact handler
+- No active session → "No active session."
+- Active session → sendPrompt("/compact"), reset messagesSinceCompact=0
+
+### maybeSendAutoCompact (called before each sendPrompt in main text path)
+- CC_TG_AUTO_COMPACT_MESSAGES (default 40, 0=disabled)
+- When messagesSinceCompact >= threshold: send /compact, reset counter, log + notify
+
+### Cost warning (in flushPending, once per session)
+- CC_TG_COST_WARN_USD (default 5.0, 0=disabled)
+- Guarded by session.costWarnSent flag
+- After flush: if costStore.get(chatId).totalCostUsd >= threshold → warn, set flag
+
+---
 
 ## Risks
-- ClaudeProcess mock: need to correctly mock EventEmitter-based spawn result
-- enrichPromptWithUrls: async, needs careful https mock setup
-- resolveClaude is a private module function — test via ClaudeProcess constructor PATH side effects
+- Claude Code may not process /effort /compact in stream-json mode — runtime concern, not a code bug.
+- Cost store is keyed by chatId (not sessionKey) — pre-existing; not changed.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Open your bot in Telegram and start chatting.
 | `ALLOWED_USER_IDS` | no | Comma-separated Telegram user IDs. Leave empty to allow anyone |
 | `CWD` | no | Working directory for Claude Code. Defaults to current directory |
 | `THREAD_CWD_MAP` | no | JSON mapping of forum topic names or IDs to CWD paths (see [Multi-topic sessions](#multi-topic-sessions)) |
+| `CC_TG_AUTO_COMPACT_MESSAGES` | no | Automatically send `/compact` after this many messages in a session (default: 40, set to 0 to disable) |
+| `CC_TG_COST_WARN_USD` | no | Send a cost warning notification when session cost exceeds this USD amount (default: 5.0, set to 0 to disable) |
 
 *One of `CLAUDE_CODE_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_API_KEY` required.
 
@@ -66,6 +68,8 @@ Message [@userinfobot](https://t.me/userinfobot) — it replies with your numeri
 | `/mcp_version` | Show latest published cc-agent npm version and current cache |
 | `/clear_npx_cache` | Clear npx cache and reload cc-agent (upgrades to latest version) |
 | `/get_file <path>` | Send a file from the server to this chat |
+| `/effort <level>` | Set Claude effort level (`low` / `medium` / `high` / `xhigh` / `max` / `auto`) |
+| `/compact` | Compact context history to free tokens |
 | `/restart` | Self-restart the cc-tg bot process (no SSH needed) |
 | Any text | Sent directly to Claude Code |
 | Voice message | Transcribed via whisper.cpp and sent to Claude |

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,15 @@
-# TODO: Comprehensive Unit Tests
+# TODO: feat/effort-control
 
-- [ ] Create branch feat/comprehensive-unit-tests
-- [ ] Add tests to formatter.test.ts
-- [ ] Add tests to tokens.test.ts
-- [ ] Add tests to usage-limit.test.ts
-- [ ] Add tests to cron.test.ts
-- [ ] Add tests to router.test.ts
-- [ ] Add tests to voice.test.ts
-- [ ] Add tests to seed.test.ts
-- [ ] Run npm test — verify all pass
+- [ ] Create branch feat/effort-control
+- [ ] Add effort + compact to BOT_COMMANDS in bot.ts
+- [ ] Add messagesSinceCompact + costWarnSent to Session interface
+- [ ] Implement handleEffort() and handleCompact()
+- [ ] Wire /effort and /compact in handleTelegram()
+- [ ] Add maybeSendAutoCompact() and call it before sendPrompt
+- [ ] Increment messagesSinceCompact in handleClaudeMessage
+- [ ] Add cost warning in flushPending
+- [ ] Update README.md with new commands and env vars
+- [ ] Write tests for new features in bot.test.ts
+- [ ] Run build (npm run build) and tests (npm test)
 - [ ] git diff --staged review
 - [ ] Commit, push, PR, merge, publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.51",
+  "version": "0.9.53",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -2116,3 +2116,360 @@ describe('/wiki commands', () => {
     expect(mocks.tgSendMessage.mock.calls[0][1]).toContain('Redis not configured');
   });
 });
+
+// ---------------------------------------------------------------------------
+// /effort command
+// ---------------------------------------------------------------------------
+
+describe('/effort command', () => {
+  let bot: CcTgBot;
+
+  async function sendCmd(text: string) {
+    await (bot as any).handleTelegram(makeMsg({ text, from: { id: 100 } }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.existsSyncMock.mockReturnValue(false);
+    mocks.cronList.mockReturnValue([]);
+    bot = new CcTgBot({ telegramToken: 'test-token' });
+  });
+
+  afterEach(() => {
+    bot.stop();
+  });
+
+  it('shows usage when no level given', async () => {
+    await sendCmd('/effort');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('Usage: /effort <level>');
+    expect(msg).toContain('low, medium, high, xhigh, max, auto');
+  });
+
+  it('shows usage for invalid level', async () => {
+    await sendCmd('/effort turbo');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('Usage: /effort <level>');
+  });
+
+  it('informs user when no active session', async () => {
+    await sendCmd('/effort high');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('No active session');
+    expect(msg).toContain('high');
+  });
+
+  it('forwards /effort to Claude when session is active', async () => {
+    // Create a session
+    await sendCmd('hello');
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    await sendCmd('/effort high');
+    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('/effort high');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('⚡ Effort set to: high');
+  });
+
+  it('is case-insensitive for level', async () => {
+    await sendCmd('hello');
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    await sendCmd('/effort HIGH');
+    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('/effort high');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('high');
+  });
+
+  it('accepts all valid levels', async () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max', 'auto']) {
+      vi.clearAllMocks();
+      mocks.tgSendMessage.mockResolvedValue({});
+      mocks.cronList.mockReturnValue([]);
+      bot.stop();
+      bot = new CcTgBot({ telegramToken: 'test-token' });
+      await sendCmd('hello');
+      vi.clearAllMocks();
+      mocks.tgSendMessage.mockResolvedValue({});
+      await sendCmd(`/effort ${level}`);
+      expect(mocks.claudeSendPrompt).toHaveBeenCalledWith(`/effort ${level}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /compact command
+// ---------------------------------------------------------------------------
+
+describe('/compact command', () => {
+  let bot: CcTgBot;
+
+  async function sendCmd(text: string) {
+    await (bot as any).handleTelegram(makeMsg({ text, from: { id: 100 } }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.existsSyncMock.mockReturnValue(false);
+    mocks.cronList.mockReturnValue([]);
+    bot = new CcTgBot({ telegramToken: 'test-token' });
+  });
+
+  afterEach(() => {
+    bot.stop();
+  });
+
+  it('replies "No active session." when no session exists', async () => {
+    await sendCmd('/compact');
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, 'No active session.');
+  });
+
+  it('sends /compact to Claude and replies with ack when session is active', async () => {
+    await sendCmd('hello');
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    await sendCmd('/compact');
+    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('/compact');
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain('🗜️');
+  });
+
+  it('resets messagesSinceCompact to 0 on /compact', async () => {
+    await sendCmd('hello');
+    // Manually bump the counter
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+    session.messagesSinceCompact = 15;
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    await sendCmd('/compact');
+    expect(session.messagesSinceCompact).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-compact threshold
+// ---------------------------------------------------------------------------
+
+describe('auto-compact (CC_TG_AUTO_COMPACT_MESSAGES)', () => {
+  let bot: CcTgBot;
+
+  async function sendCmd(text: string) {
+    await (bot as any).handleTelegram(makeMsg({ text, from: { id: 100 } }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.existsSyncMock.mockReturnValue(false);
+    mocks.cronList.mockReturnValue([]);
+    bot = new CcTgBot({ telegramToken: 'test-token' });
+    delete process.env.CC_TG_AUTO_COMPACT_MESSAGES;
+  });
+
+  afterEach(() => {
+    bot.stop();
+    delete process.env.CC_TG_AUTO_COMPACT_MESSAGES;
+  });
+
+  it('does not fire when count is below threshold', async () => {
+    process.env.CC_TG_AUTO_COMPACT_MESSAGES = '5';
+    await sendCmd('hello');
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+    session.messagesSinceCompact = 3;
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    await sendCmd('another message');
+    // /compact should NOT have been sent
+    expect(mocks.claudeSendPrompt).not.toHaveBeenCalledWith('/compact');
+  });
+
+  it('fires /compact when messagesSinceCompact reaches threshold', async () => {
+    process.env.CC_TG_AUTO_COMPACT_MESSAGES = '5';
+    await sendCmd('hello');
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+    session.messagesSinceCompact = 5;
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    await sendCmd('another message');
+    // First call is /compact, second call is the actual prompt
+    expect(mocks.claudeSendPrompt).toHaveBeenCalledWith('/compact');
+  });
+
+  it('resets messagesSinceCompact to 0 after auto-compact fires', async () => {
+    process.env.CC_TG_AUTO_COMPACT_MESSAGES = '5';
+    await sendCmd('hello');
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+    session.messagesSinceCompact = 5;
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    await sendCmd('another message');
+    expect(session.messagesSinceCompact).toBe(0);
+  });
+
+  it('is disabled when CC_TG_AUTO_COMPACT_MESSAGES=0', async () => {
+    process.env.CC_TG_AUTO_COMPACT_MESSAGES = '0';
+    await sendCmd('hello');
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+    session.messagesSinceCompact = 100;
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    await sendCmd('another message');
+    expect(mocks.claudeSendPrompt).not.toHaveBeenCalledWith('/compact');
+  });
+
+  it('increments messagesSinceCompact on each Claude result', async () => {
+    await sendCmd('hello');
+    const onCalls = mocks.claudeOn.mock.calls as [string, (...args: unknown[]) => void][];
+    const messageHandler = onCalls.find(([event]) => event === 'message')?.[1];
+    const sessions = (bot as any).sessions as Map<string, { messagesSinceCompact: number }>;
+    const session = sessions.get('42:main')!;
+
+    expect(session.messagesSinceCompact).toBe(0);
+    messageHandler?.({ type: 'result', payload: { result: 'response' }, raw: {} });
+    expect(session.messagesSinceCompact).toBe(1);
+    messageHandler?.({ type: 'result', payload: { result: 'response 2' }, raw: {} });
+    expect(session.messagesSinceCompact).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cost warning (CC_TG_COST_WARN_USD)
+// ---------------------------------------------------------------------------
+
+describe('cost warning (CC_TG_COST_WARN_USD)', () => {
+  let bot: CcTgBot;
+
+  async function sendCmd(text: string) {
+    await (bot as any).handleTelegram(makeMsg({ text, from: { id: 100 } }));
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+    mocks.tgSetMyCommands.mockResolvedValue({});
+    mocks.existsSyncMock.mockReturnValue(false);
+    mocks.cronList.mockReturnValue([]);
+    bot = new CcTgBot({ telegramToken: 'test-token' });
+    delete process.env.CC_TG_COST_WARN_USD;
+  });
+
+  afterEach(() => {
+    bot.stop();
+    delete process.env.CC_TG_COST_WARN_USD;
+    vi.useRealTimers();
+  });
+
+  it('sends warning when session cost exceeds threshold', async () => {
+    process.env.CC_TG_COST_WARN_USD = '1.0';
+    await sendCmd('hello');
+
+    const onCalls = mocks.claudeOn.mock.calls as [string, (...args: unknown[]) => void][];
+    const usageHandler = onCalls.find(([event]) => event === 'usage')?.[1];
+    const messageHandler = onCalls.find(([event]) => event === 'message')?.[1];
+
+    // Push cost above threshold: 1M output tokens = $15
+    usageHandler!({ inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 });
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    messageHandler?.({ type: 'result', payload: { result: 'done' }, raw: {} });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const calls = mocks.tgSendMessage.mock.calls.map((c) => c[1] as string);
+    const warnCall = calls.find((m) => m.includes('⚠️'));
+    expect(warnCall).toBeDefined();
+    expect(warnCall).toContain('consider /compact or /reset');
+  });
+
+  it('does not send warning when cost is below threshold', async () => {
+    process.env.CC_TG_COST_WARN_USD = '100.0';
+    await sendCmd('hello');
+
+    const onCalls = mocks.claudeOn.mock.calls as [string, (...args: unknown[]) => void][];
+    const messageHandler = onCalls.find(([event]) => event === 'message')?.[1];
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    messageHandler?.({ type: 'result', payload: { result: 'done' }, raw: {} });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const calls = mocks.tgSendMessage.mock.calls.map((c) => c[1] as string);
+    expect(calls.find((m) => m.includes('⚠️'))).toBeUndefined();
+  });
+
+  it('sends warning only once per session', async () => {
+    process.env.CC_TG_COST_WARN_USD = '1.0';
+    await sendCmd('hello');
+
+    const onCalls = mocks.claudeOn.mock.calls as [string, (...args: unknown[]) => void][];
+    const usageHandler = onCalls.find(([event]) => event === 'usage')?.[1];
+    const messageHandler = onCalls.find(([event]) => event === 'message')?.[1];
+
+    // Push cost above threshold
+    usageHandler!({ inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 });
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    // First result
+    messageHandler?.({ type: 'result', payload: { result: 'done' }, raw: {} });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const firstWarnCount = mocks.tgSendMessage.mock.calls.filter((c) =>
+      (c[1] as string).includes('⚠️')
+    ).length;
+    expect(firstWarnCount).toBe(1);
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    // Second result — warning should NOT fire again
+    messageHandler?.({ type: 'result', payload: { result: 'done again' }, raw: {} });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const secondWarnCount = mocks.tgSendMessage.mock.calls.filter((c) =>
+      (c[1] as string).includes('⚠️')
+    ).length;
+    expect(secondWarnCount).toBe(0);
+  });
+
+  it('is disabled when CC_TG_COST_WARN_USD=0', async () => {
+    process.env.CC_TG_COST_WARN_USD = '0';
+    await sendCmd('hello');
+
+    const onCalls = mocks.claudeOn.mock.calls as [string, (...args: unknown[]) => void][];
+    const usageHandler = onCalls.find(([event]) => event === 'usage')?.[1];
+    const messageHandler = onCalls.find(([event]) => event === 'message')?.[1];
+
+    usageHandler!({ inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 });
+
+    vi.clearAllMocks();
+    mocks.tgSendMessage.mockResolvedValue({});
+
+    messageHandler?.({ type: 'result', payload: { result: 'done' }, raw: {} });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const calls = mocks.tgSendMessage.mock.calls.map((c) => c[1] as string);
+    expect(calls.find((m) => m.includes('⚠️'))).toBeUndefined();
+  });
+});

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -40,6 +40,8 @@ const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "drivers", description: "List available agent drivers" },
   { command: "agents", description: "Show running meta-agents and their live status" },
   { command: "wiki", description: "Manage wiki pages — list/show/update/delete/sync" },
+  { command: "effort", description: "Set effort level: low / medium / high / xhigh / max / auto" },
+  { command: "compact", description: "Compact context history to free tokens" },
 ];
 
 export interface BotOptions {
@@ -69,6 +71,10 @@ interface Session {
   isRetry: boolean;
   /** Forum topic thread_id (undefined for DMs and non-topic groups) */
   threadId?: number;
+  /** Messages sent since last /compact — used for auto-compact threshold */
+  messagesSinceCompact: number;
+  /** True once the CC_TG_COST_WARN_USD threshold notification has been sent */
+  costWarnSent: boolean;
 }
 
 interface PendingRetry {
@@ -561,6 +567,18 @@ export class CcTgBot {
       return;
     }
 
+    // /effort <level> — forward effort level to active Claude session
+    if (text.startsWith("/effort")) {
+      await this.handleEffort(chatId, text, threadId);
+      return;
+    }
+
+    // /compact — compact context history in active Claude session
+    if (text === "/compact") {
+      await this.handleCompact(chatId, threadId);
+      return;
+    }
+
     // #tag / #org/repo routing — delegate to meta-agent instead of local Claude session
     if (this.redis) {
       const routing = parseRoutingTag(text);
@@ -631,6 +649,7 @@ export class CcTgBot {
       const enriched = await enrichPromptWithUrls(text);
       const prompt = buildPromptWithReplyContext(enriched, msg);
       session.currentPrompt = prompt;
+      this.maybeSendAutoCompact(session, chatId, threadId);
       session.claude.sendPrompt(stampPrompt(prompt));
       this.startTyping(chatId, session);
       this.writeChatMessage("user", "telegram", text, chatId);
@@ -926,6 +945,8 @@ export class CcTgBot {
       currentPrompt: "",
       isRetry: false,
       threadId,
+      messagesSinceCompact: 0,
+      costWarnSent: false,
     };
 
     claude.on("usage", (usage: UsageEvent) => {
@@ -992,6 +1013,7 @@ export class CcTgBot {
 
     this.stopTyping(session);
     this.costStore.incrementMessages(chatId);
+    session.messagesSinceCompact++;
 
     const text = extractText(msg);
     if (!text) return;
@@ -1112,6 +1134,22 @@ export class CcTgBot {
       this.uploadMentionedFiles(chatId, text, session);
     } catch (err) {
       console.error(`[tg:${chatId}] uploadMentionedFiles error:`, (err as Error).message);
+    }
+
+    // Cost threshold warning — fires once per session when cost first exceeds the limit
+    if (!session.costWarnSent) {
+      const warnThreshold = parseFloat(process.env.CC_TG_COST_WARN_USD ?? "5.0");
+      if (!isNaN(warnThreshold) && warnThreshold > 0) {
+        const cost = this.costStore.get(chatId);
+        if (cost.totalCostUsd >= warnThreshold) {
+          session.costWarnSent = true;
+          this.replyToChat(
+            chatId,
+            `⚠️ Session cost: $${cost.totalCostUsd.toFixed(2)} — consider /compact or /reset`,
+            threadId
+          ).catch(() => {});
+        }
+      }
     }
   }
 
@@ -1901,6 +1939,63 @@ export class CcTgBot {
       this.stopTyping(session);
       session.claude.kill();
       this.sessions.delete(key);
+    }
+  }
+
+  private async handleEffort(chatId: number, text: string, threadId?: number): Promise<void> {
+    const VALID_LEVELS = new Set(["low", "medium", "high", "xhigh", "max", "auto"]);
+    const parts = text.trim().split(/\s+/);
+    const level = parts[1]?.toLowerCase();
+    if (!level || !VALID_LEVELS.has(level)) {
+      await this.replyToChat(
+        chatId,
+        "Usage: /effort <level>\nValid levels: low, medium, high, xhigh, max, auto",
+        threadId
+      );
+      return;
+    }
+    const sessionKey = this.sessionKey(chatId, threadId);
+    const session = this.sessions.get(sessionKey);
+    if (!session || session.claude.exited) {
+      await this.replyToChat(
+        chatId,
+        `No active session. Start one, then use /effort ${level} to set the effort level.`,
+        threadId
+      );
+      return;
+    }
+    session.claude.sendPrompt(`/effort ${level}`);
+    await this.replyToChat(chatId, `⚡ Effort set to: ${level}`, threadId);
+  }
+
+  private async handleCompact(chatId: number, threadId?: number): Promise<void> {
+    const sessionKey = this.sessionKey(chatId, threadId);
+    const session = this.sessions.get(sessionKey);
+    if (!session || session.claude.exited) {
+      await this.replyToChat(chatId, "No active session.", threadId);
+      return;
+    }
+    session.claude.sendPrompt("/compact");
+    session.messagesSinceCompact = 0;
+    await this.replyToChat(chatId, "🗜️ Compacting context history...", threadId);
+  }
+
+  /**
+   * If CC_TG_AUTO_COMPACT_MESSAGES threshold is reached, send /compact to the active Claude
+   * session before the next user message. Resets the per-session counter on fire.
+   */
+  private maybeSendAutoCompact(session: Session, chatId: number, threadId?: number): void {
+    const threshold = parseInt(process.env.CC_TG_AUTO_COMPACT_MESSAGES ?? "40", 10);
+    if (isNaN(threshold) || threshold <= 0) return;
+    if (session.messagesSinceCompact >= threshold) {
+      console.log(`[auto-compact:${chatId}] firing after ${session.messagesSinceCompact} messages`);
+      session.messagesSinceCompact = 0;
+      session.claude.sendPrompt("/compact");
+      this.replyToChat(
+        chatId,
+        `🗜️ Auto-compacting context (${threshold} message limit reached)...`,
+        threadId
+      ).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary

- **`/effort <level>`** — Forwards effort level (`low`/`medium`/`high`/`xhigh`/`max`/`auto`) to the active Claude Code session via stdin, same as regular messages. Shows usage/error when no session is active.
- **`/compact`** — Manually compacts the context history in the active Claude session. Resets the auto-compact message counter.
- **`CC_TG_AUTO_COMPACT_MESSAGES`** (default: 40) — After N messages in a session, automatically sends `/compact` to the Claude subprocess before the next user message. Logs when it fires. Set to 0 to disable.
- **`CC_TG_COST_WARN_USD`** (default: 5.0) — After each response, if session cost first exceeds this threshold, sends: `⚠️ Session cost: $X.XX — consider /compact or /reset`. Fires once per session. Set to 0 to disable.

## Test plan

- [x] `/effort` with no level → usage message
- [x] `/effort turbo` (invalid) → usage message
- [x] `/effort high` with no session → "No active session" + hint
- [x] `/effort high` with active session → `sendPrompt("/effort high")` called, ack sent
- [x] `/effort HIGH` → case-insensitive, forwards as lowercase
- [x] `/compact` with no session → "No active session."
- [x] `/compact` with active session → `sendPrompt("/compact")`, resets counter
- [x] Auto-compact fires when `messagesSinceCompact >= threshold`
- [x] Auto-compact does not fire below threshold
- [x] Auto-compact resets counter to 0 after firing
- [x] Auto-compact disabled when `CC_TG_AUTO_COMPACT_MESSAGES=0`
- [x] `messagesSinceCompact` increments on each Claude result
- [x] Cost warning fires once when cost exceeds threshold
- [x] Cost warning does not fire below threshold
- [x] Cost warning fires only once per session
- [x] Cost warning disabled when `CC_TG_COST_WARN_USD=0`
- [x] 741 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)