### PR TITLE
fix: reject numeric hashtag routing (#57 and similar)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,74 +1,41 @@
-# PLAN.md — feat/effort-control
+# PLAN.md — fix/router-numeric-hashtag
 
 ## Task Restatement
-Add effort level control (`/effort <level>`), manual context compaction (`/compact`),
-auto-compact after N messages (`CC_TG_AUTO_COMPACT_MESSAGES`), and a session cost warning
-(`CC_TG_COST_WARN_USD`) to the cc-tg Telegram bot. Also update `/help` and README.
+`parseRoutingTag()` in `src/router.ts` currently matches `#57`, `#123`, `#2fast` as valid
+routing tags because the regex first character class is `[a-zA-Z0-9]`. This causes Telegram
+messages containing issue/PR reference numbers to spawn ghost meta-agent namespaces.
+Fix: require the first character after `#` to be alphabetic (`[a-zA-Z]`).
 
 ---
 
 ## Approaches Considered
 
-### A) Forward slash commands verbatim to Claude subprocess stdin (CHOSEN)
-Forward `/effort high` and `/compact` to Claude via `session.claude.sendPrompt()`.
-**Pro**: Zero new abstractions; exactly what the spec says.
-**Con**: Relies on Claude Code's stream-json input layer processing slash commands.
+### A) Require alphabetic first character in regex (CHOSEN)
+Change `#([a-zA-Z0-9][a-zA-Z0-9._-]*)` → `#([a-zA-Z][a-zA-Z0-9._-]*)`.
+**Pro**: One-character change, surgical, matches the spec exactly.
+**Con**: None.
 
-### B) Pass effort/compact as CLI flags on process spawn
-Kill existing session and re-spawn with `--effort high` flag.
-**Con**: Loses conversation history; ugly UX. Rejected.
+### B) Post-match validation (reject if namespace is all-digits)
+After matching, check `if (/^\d+$/.test(namespace)) return null`.
+**Con**: More code; still fails for `#2fast`-style mixed tags.
 
-### C) Custom JSON message type
-Add `{ type: "command", command: "effort", value: "high" }`.
-**Con**: Claude Code doesn't define such a type. Rejected.
+### C) Require at least 2 characters
+Ensure namespace is `[a-zA-Z][a-zA-Z0-9._-]+` (one or more after the letter).
+**Con**: Would reject single-letter tags like `#a` which are valid real repo names.
 
 ---
 
-## Approach: A — forward via sendPrompt
+## Approach: A
 
 ---
 
 ## Files to Touch
-- `src/bot.ts` — core changes: commands, session fields, auto-compact, cost warning
-- `src/bot.test.ts` — tests for new features
-- `README.md` — document new commands and env vars
-
----
-
-## Implementation Details
-
-### Session interface additions
-```
-messagesSinceCompact: number   // incremented per-response; reset on /compact
-costWarnSent: boolean           // true once cost threshold notification is sent
-```
-
-### BOT_COMMANDS additions
-```
-{ command: "effort", description: "Set effort level: low / medium / high / xhigh / max / auto" }
-{ command: "compact", description: "Compact context history to free tokens" }
-```
-
-### /effort handler
-- Validate level in Set(["low","medium","high","xhigh","max","auto"])
-- No active session → informational reply
-- Active session → sendPrompt("/effort ${level}") + ack
-
-### /compact handler
-- No active session → "No active session."
-- Active session → sendPrompt("/compact"), reset messagesSinceCompact=0
-
-### maybeSendAutoCompact (called before each sendPrompt in main text path)
-- CC_TG_AUTO_COMPACT_MESSAGES (default 40, 0=disabled)
-- When messagesSinceCompact >= threshold: send /compact, reset counter, log + notify
-
-### Cost warning (in flushPending, once per session)
-- CC_TG_COST_WARN_USD (default 5.0, 0=disabled)
-- Guarded by session.costWarnSent flag
-- After flush: if costStore.get(chatId).totalCostUsd >= threshold → warn, set flag
+- `src/router.ts` — fix the regex and update the inline comment + JSDoc
+- `src/router.test.ts` — add tests for `#57`, `#123abc`, `#2fast`, update existing comment
 
 ---
 
 ## Risks
-- Claude Code may not process /effort /compact in stream-json mode — runtime concern, not a code bug.
-- Cost store is keyed by chatId (not sessionKey) — pre-existing; not changed.
+- The `#org/repo` format also uses the same first character class for `part1` (the org).
+  Changing the constraint means `#57/repo` won't route either, which is correct behaviour.
+- No other callers of `parseRoutingTag` in the codebase need changes.

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,9 @@
-# TODO: feat/effort-control
+# TODO: fix/router-numeric-hashtag
 
-- [ ] Create branch feat/effort-control
-- [ ] Add effort + compact to BOT_COMMANDS in bot.ts
-- [ ] Add messagesSinceCompact + costWarnSent to Session interface
-- [ ] Implement handleEffort() and handleCompact()
-- [ ] Wire /effort and /compact in handleTelegram()
-- [ ] Add maybeSendAutoCompact() and call it before sendPrompt
-- [ ] Increment messagesSinceCompact in handleClaudeMessage
-- [ ] Add cost warning in flushPending
-- [ ] Update README.md with new commands and env vars
-- [ ] Write tests for new features in bot.test.ts
-- [ ] Run build (npm run build) and tests (npm test)
+- [ ] Create branch fix/router-numeric-hashtag
+- [ ] Fix regex in src/router.ts: [a-zA-Z0-9] → [a-zA-Z] as first char
+- [ ] Update inline comment and JSDoc in src/router.ts
+- [ ] Add tests in src/router.test.ts: #57, #123abc, #2fast return null
+- [ ] Run build + tests
 - [ ] git diff --staged review
 - [ ] Commit, push, PR, merge, publish

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -113,9 +113,37 @@ describe("parseRoutingTag", () => {
   });
 
   it("returns null when tag starts with a dash (#-repo is invalid)", () => {
-    // Regex requires [a-zA-Z0-9] as first char after #
+    // Regex requires [a-zA-Z] as first char after #
     process.env.DEFAULT_GITHUB_ORG = "gonzih";
     expect(parseRoutingTag("#-repo fix it")).toBeNull();
+  });
+
+  it("returns null for purely numeric tag (#57)", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    expect(parseRoutingTag("see issue #57 for context")).toBeNull();
+  });
+
+  it("returns null for purely numeric tag at start (#123)", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    expect(parseRoutingTag("#123 do something")).toBeNull();
+  });
+
+  it("returns null for digit-leading mixed tag (#2fast)", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    expect(parseRoutingTag("#2fast deploy")).toBeNull();
+  });
+
+  it("returns null for digit-leading tag (#123abc)", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    expect(parseRoutingTag("#123abc run this")).toBeNull();
+  });
+
+  it("still routes alphabetic tag that appears alongside a numeric reference", () => {
+    process.env.DEFAULT_GITHUB_ORG = "gonzih";
+    // The #57 reference is in the text but #cc-agent comes after — should still route
+    const result = parseRoutingTag("see #57 and ask #cc-agent to fix it");
+    expect(result).not.toBeNull();
+    expect(result!.namespace).toBe("cc-agent");
   });
 
   it("handles repo name with dots and underscores (#org/my_repo.v2)", () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,9 @@
  * Tag formats:
  *   #repo-name    → namespace=repo-name, repo=https://github.com/{DEFAULT_GITHUB_ORG}/repo-name (null if DEFAULT_GITHUB_ORG unset)
  *   #org/repo     → namespace=repo,      repo=https://github.com/org/repo
+ *
+ * The namespace (first segment after #) MUST start with a letter. Purely numeric
+ * or digit-leading tags such as #57 or #123 are rejected and treated as plain text.
  */
 
 import { execSync } from "child_process";
@@ -25,20 +28,28 @@ export interface RoutingTag {
 
 /**
  * Parse the first #tag or #org/repo token from a message.
- * Returns null when no routing tag is present, or when the short #repo format is used
- * without DEFAULT_GITHUB_ORG being set (operators must configure this explicitly).
+ * Returns null when no routing tag is present, when the short #repo format is used
+ * without DEFAULT_GITHUB_ORG being set, or when the tag starts with a digit.
+ *
+ * The namespace segment must begin with a letter. Tags like #57 or #123 that start
+ * with a digit are rejected so that numeric issue/PR references in pasted text are
+ * not mistaken for routing targets.
  *
  * Examples:
  *   "#cc-agent fix the bug"           → null if DEFAULT_GITHUB_ORG unset; { namespace: "cc-agent", repoUrl: "…/{org}/cc-agent", … } if set
  *   "#gonzih/of-stack deploy it"      → { namespace: "of-stack", repoUrl: "…/gonzih/of-stack", … }
  *   "#org/repo do something"          → { namespace: "repo",     repoUrl: "…/org/repo", … }
  *   "please help #of-stack with this" → null if DEFAULT_GITHUB_ORG unset
+ *   "see issue #57 for context"       → null (digit-leading tag rejected)
+ *   "#2fast deploy"                   → null (digit-leading tag rejected)
  */
 export function parseRoutingTag(text: string): RoutingTag | null {
   const defaultOrg = process.env.DEFAULT_GITHUB_ORG;
 
-  // Match #word or #org/repo — each segment: starts with alphanumeric, allows ._- inside
-  const match = text.match(/#([a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\/([a-zA-Z0-9][a-zA-Z0-9._-]*))?/);
+  // Match #word or #org/repo — first segment must start with a letter (not a digit),
+  // subsequent characters allow alphanumeric, dots, underscores, and hyphens.
+  // This prevents numeric issue references like #57 from being treated as routing tags.
+  const match = text.match(/#([a-zA-Z][a-zA-Z0-9._-]*)(?:\/([a-zA-Z0-9][a-zA-Z0-9._-]*))?/);
   if (!match) return null;
 
   const fullMatch = match[0]; // e.g. "#gonzih/of-stack"


### PR DESCRIPTION
## Summary

- Tags starting with a digit (e.g. `#57`, `#123`, `#2fast`) were being parsed as meta-agent routing targets by `parseRoutingTag()`, sending messages to ghost namespaces
- Root cause: first character class in the regex was `[a-zA-Z0-9]`, allowing digit-led tags
- Fix: change to `[a-zA-Z]` — namespace must start with a letter
- Valid tags like `#cc-agent`, `#gonzih/of-stack`, `#simorgh-app` continue to work unchanged

## Test plan

- [x] `#57` → `null` (new test)
- [x] `#123` → `null` (new test)
- [x] `#2fast` → `null` (new test)
- [x] `#123abc` → `null` (new test)
- [x] `"see #57 and ask #cc-agent to fix it"` → routes to `cc-agent` namespace (new test)
- [x] All 746 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)