### PR TITLE
feat: skip notifications with discord_only flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.55",
+  "version": "0.9.57",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { startNotifier, writeChatLog, parseNotification, type ChatMessage } from "./notifier.js";
+import { startNotifier, writeChatLog, parseNotification, isDiscordOnly, type ChatMessage } from "./notifier.js";
 
 // ---- ioredis mock ----
 const mockSubscribe = vi.fn().mockImplementation((_channel: string, cb?: (err: Error | null) => void) => {
@@ -1028,6 +1028,40 @@ describe("parseNotification", () => {
     expect(bot.sendMessage).toHaveBeenCalledWith(456, "Job done");
   });
 
+  it("pub/sub handler skips discord_only:true notifications (nothing sent to Telegram)", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 456, "myns", redis as never);
+
+    messageHandler!("cca:notify:myns", JSON.stringify({ text: "hello", discord_only: true }));
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("pub/sub handler sends discord_only:false notifications normally", () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 456, "myns", redis as never);
+
+    messageHandler!("cca:notify:myns", JSON.stringify({ text: "hello", discord_only: false }));
+    expect(bot.sendMessage).toHaveBeenCalledWith(456, "hello");
+  });
+
   it("pub/sub handler uses parseNotification — JSON badge appears in sent message", () => {
     // This is an integration check through the message handler
     const bot = makeBot();
@@ -1061,6 +1095,116 @@ describe("parseNotification", () => {
     messageHandler!("cca:notify:ns2", JSON.stringify({ text: "✅ done", driver: "claude", model: "claude-sonnet-4-6", cost: 1.23 }));
 
     expect(bot.sendMessage).toHaveBeenCalledWith(42, "✅ done\n[claude:sonnet-4-6] cost: $1.230");
+  });
+});
+
+describe("isDiscordOnly", () => {
+  it("returns false for plain string", () => {
+    expect(isDiscordOnly("plain text")).toBe(false);
+  });
+
+  it("returns false when discord_only is absent", () => {
+    expect(isDiscordOnly(JSON.stringify({ text: "hello" }))).toBe(false);
+  });
+
+  it("returns false when discord_only is false", () => {
+    expect(isDiscordOnly(JSON.stringify({ text: "hello", discord_only: false }))).toBe(false);
+  });
+
+  it("returns true when discord_only is true", () => {
+    expect(isDiscordOnly(JSON.stringify({ text: "hello", discord_only: true }))).toBe(true);
+  });
+
+  it("returns false for invalid JSON", () => {
+    expect(isDiscordOnly("{bad json")).toBe(false);
+  });
+});
+
+describe("notify list poller — discord_only filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGet.mockResolvedValue(null);
+    mockRpop.mockResolvedValue(null);
+    mockLlen.mockResolvedValue(0);
+    const sub = {
+      subscribe: mockSubscribe,
+      psubscribe: mockPsubscribe,
+      on: mockOn,
+      lpush: mockLpush,
+      ltrim: mockLtrim,
+      publish: mockPublish,
+      get: mockGet,
+    };
+    mockDuplicate.mockReturnValue(sub);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips discord_only:true items in the list (nothing sent to Telegram)", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "discord only", discord_only: true }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 111, "ns-discord", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends items without discord_only flag normally", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "normal notification" }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 222, "ns-normal", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(222, "normal notification");
+  });
+
+  it("sends items with discord_only:false normally", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "not discord only", discord_only: false }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 333, "ns-not-discord", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(333, "not discord only");
+  });
+
+  it("skips discord_only items but still sends regular items in the same batch", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+
+    mockRpop
+      .mockResolvedValueOnce(JSON.stringify({ text: "send me", discord_only: false }))
+      .mockResolvedValueOnce(JSON.stringify({ text: "skip me", discord_only: true }))
+      .mockResolvedValueOnce(JSON.stringify({ text: "send me too" }))
+      .mockResolvedValue(null);
+
+    startNotifier(bot as never, 444, "ns-mixed", redis as never);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(2);
+    expect(bot.sendMessage).toHaveBeenCalledWith(444, "send me");
+    expect(bot.sendMessage).toHaveBeenCalledWith(444, "send me too");
   });
 });
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -59,6 +59,19 @@ function stripAnsi(text: string): string {
 }
 
 /**
+ * Returns true when the notification payload has discord_only: true.
+ * These messages are intended for Discord only and must be silently skipped by Telegram.
+ */
+export function isDiscordOnly(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw) as { discord_only?: boolean };
+    return parsed.discord_only === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Parse a notification payload and return the display text.
  * Appends a [driver] or [driver:model] badge whenever the driver field is present.
  * Appends " cost: $X.XXX" if a numeric cost field is present.
@@ -284,6 +297,7 @@ export function startNotifier(
     }
 
     for (const raw of items) {
+      if (isDiscordOnly(raw)) continue;
       const text = parseNotification(raw);
       bot.sendMessage(targetId, text).catch((err: Error) => {
         log("warn", "notify list sendMessage failed:", err.message);
@@ -309,6 +323,7 @@ export function startNotifier(
     const incomingCh = chatIncomingChannel(namespace);
 
     if (channel === notifyCh) {
+      if (isDiscordOnly(message)) return;
       const targetId = chatId ?? getActiveChatId?.();
       if (targetId != null) {
         const text = parseNotification(message);


### PR DESCRIPTION
## Summary

- Adds `isDiscordOnly(raw: string): boolean` helper to `src/notifier.ts` (exported)
- Both the pub/sub handler and the list poller now check `discord_only: true` before forwarding to Telegram
- Payload with `discord_only: false` or no flag continues to send as before

## Test plan

- [x] Unit tests for `isDiscordOnly` (absent/false/true/invalid JSON)
- [x] Integration test: pub/sub skips `discord_only: true` payload
- [x] Integration test: pub/sub sends `discord_only: false` payload normally
- [x] Integration test: list poller skips `discord_only: true` items
- [x] Integration test: list poller sends normal items, skips discord-only in same batch
- [x] All 663 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)