### PR TITLE
fix: pass spawning_namespace when spawning agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-tg",
-  "version": "0.9.57",
+  "version": "0.9.59",
   "description": "Claude Code Telegram bot — chat with Claude Code via Telegram",
   "type": "module",
   "bin": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1756,7 +1756,7 @@ export class CcTgBot {
     if (spawnTools.has(toolName)) {
       const driver = process.env.CC_AGENT_DEFAULT_DRIVER || "claude";
       const model = process.env.CC_AGENT_DEFAULT_MODEL || undefined;
-      args = { agent_driver: driver, ...(model ? { agent_model: model } : {}), ...args };
+      args = { agent_driver: driver, ...(model ? { agent_model: model } : {}), spawning_namespace: this.namespace, ...args };
     }
 
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Adds `spawning_namespace: this.namespace` to the args injected for `spawn_agent` and `spawn_from_profile` MCP tool calls
- Ensures job completion notifications route back to `cca:notify:{namespace}` for the cc-tg instance that spawned the agent, not always to the default/money-brain channel
- The namespace is already known at runtime — it's the same value used for cc-tg's own Redis keys and meta-agent session

## Test plan
- [x] All 684 existing tests pass
- [x] Build passes cleanly (`tsc`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)