### PR TITLE
fix: route messages to idle meta-agents, not just running ones

### DIFF
--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -308,7 +308,9 @@ describe("startNotifier", () => {
     expect(bot.sendMessage).toHaveBeenCalledWith(100, "📱 [from UI]: hello meta");
   });
 
-  it("falls back to handleUserMessage when meta-agent status is not running", async () => {
+  it("routes to meta-agent input queue when meta-agent status is idle (registered, waiting)", async () => {
+    // Idle meta-agents are registered and ready for messages — they SHOULD receive them.
+    // The cc-agent poller handles concurrency; cc-tg just needs to route to the queue.
     const bot = makeBot();
     const redis = makeRedis();
     const handleUserMessage = vi.fn();
@@ -324,13 +326,40 @@ describe("startNotifier", () => {
 
     startNotifier(bot as never, 200, "ns-idle", redis as never, handleUserMessage);
 
-    messageHandler!("cca:chat:incoming:ns-idle", "hello coord");
+    messageHandler!("cca:chat:incoming:ns-idle", "hello meta");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockRpush).toHaveBeenCalledWith(
+      "cca:meta:ns-idle:input",
+      expect.stringContaining('"content":"hello meta"')
+    );
+    expect(handleUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to handleUserMessage when meta-agent status key does not exist", async () => {
+    const bot = makeBot();
+    const redis = makeRedis();
+    const handleUserMessage = vi.fn();
+
+    mockGet.mockResolvedValue(null); // no status key — meta-agent not registered
+
+    let messageHandler: ((channel: string, message: string) => void) | undefined;
+    mockOn.mockImplementation((event: string, handler: unknown) => {
+      if (event === "message") {
+        messageHandler = handler as (channel: string, message: string) => void;
+      }
+    });
+
+    startNotifier(bot as never, 200, "ns-unregistered", redis as never, handleUserMessage);
+
+    messageHandler!("cca:chat:incoming:ns-unregistered", "hello coord");
 
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handleUserMessage).toHaveBeenCalledWith(200, "hello coord");
     expect(mockRpush).not.toHaveBeenCalledWith(
-      "cca:meta:ns-idle:input",
+      "cca:meta:ns-unregistered:input",
       expect.anything()
     );
   });

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -387,14 +387,17 @@ export function startNotifier(
         };
         writeChatLog(redis, namespace, inMsg);
 
-        // Check if a meta-agent is running for this namespace; if so, route there instead
+        // Check if a meta-agent is registered for this namespace; if so, route there instead.
+        // Route for both "running" (actively processing) and "idle" (registered, waiting for input).
+        // The cc-agent poller handles concurrency: if busy, the message stays queued until the
+        // current turn finishes. Routing is gated on status key existence, not "running" only.
         void (async () => {
           let routedToMetaAgent = false;
           try {
             const statusRaw = await redis.get(metaAgentStatusKey(namespace));
             if (statusRaw) {
               const status = JSON.parse(statusRaw) as { status?: string };
-              if (status.status === "running") {
+              if (status.status === "running" || status.status === "idle") {
                 const entry = JSON.stringify({
                   id: crypto.randomUUID(),
                   content,


### PR DESCRIPTION
## Root cause

cc-tg routed incoming Telegram/UI messages to a meta-agent only when the Redis status key held status: "running". Freshly started meta-agents (via start_meta_agent) have status: "idle" — they are registered and ready, just not currently processing a turn. This meant every message to a new meta-agent was silently dropped and routed to the coordinator instead.

## Fix

Change the routing condition in notifier.ts from status.status === "running" to status.status === "running" || status.status === "idle".

The cc-agent poller handles concurrency correctly: if the agent is mid-turn, the message stays in the Redis queue and is picked up at the next 3s poll. cc-tg routing only needs to distinguish registered meta-agent from no meta-agent at all.

## Tests

- Updated existing test: idle agents now correctly receive messages
- Added new test: fallback when status key does not exist (unregistered namespace)
- All 685 tests pass

Generated with Claude Code