### PR TITLE
feat: loop state tracking and gate-based re-prompt in cc-tg sessions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,46 +1,31 @@
-# PLAN.md — feat/remove-hashtag-routing
+# PLAN.md — feat/loop-state-tracking
 
 ## Task Restatement
-Remove all automatic hashtag-triggered meta-agent routing from cc-tg. This includes
-the `#tag` / `#org/repo` pattern that spawned external meta-agents, and the forum-topic
-based routing that used the same underlying functions. After removal, all Telegram
-messages go directly to the local Claude session. The `/agents` command and notifier
-wiring remain untouched.
-
----
+Add loop state tracking to cc-tg sessions so that goal-oriented messages automatically verify
+completion after each Claude response and re-prompt on failure, up to a configurable maximum.
+Users see only the final result (happy path invisible), a `/loop_status` command, and a
+`/loop_stop` escape hatch.
 
 ## Approach
-Single surgical removal pass — delete the router module and all call sites in bot.ts
-and the associated tests. No replacement logic needed.
+Single-pass implementation directly in `src/bot.ts`:
+1. Add `LoopState` interface and optional `loopState` field to `Session`
+2. Add `classifyMessage(text)` — heuristic to distinguish goal vs question
+3. Add `checkCompletionGate(text)` — regex scan for completion signals in response text
+4. Intercept in `handleClaudeMessage` after text extraction: when `loopState` is active, run the gate before accumulating `pendingText`; re-prompt or flush-with-trace accordingly
+5. Initialize `loopState` in the normal message-send path when `classifyMessage` returns "goal"
+6. Add `/loop_status` and `/loop_stop` commands + BOT_COMMANDS entries
+7. Write tests in a new `src/loop-state.test.ts` file
 
-**Files to change:**
-- `src/router.ts` — delete entirely (parseRoutingTag, RoutingTag, ensureMetaAgent, routeToMetaAgent, CallToolFn)
-- `src/router.test.ts` — delete entirely
-- `src/forum-routing.test.ts` — delete entirely (tests normalizeTopicNamespace + forum routing)
-- `src/bot.ts`:
-  - Remove import of parseRoutingTag, ensureMetaAgent, routeToMetaAgent from ./router.js
-  - Remove `topicNameCache` private field
-  - Remove topicNameCache population block (~lines 367-386)
-  - Remove hashtag routing block (~lines 582-608)
-  - Remove forum routing block (~lines 610-645)
-  - Remove `getForumRoutingConfig()` method
-  - Remove `normalizeTopicNamespace` exported function
-- `src/bot.error.test.ts`:
-  - Remove parseRoutingTagMock, ensureMetaAgentMock, routeToMetaAgentMock from mocks
-  - Remove `vi.mock('./router.js', ...)` block
-  - Remove describe section 3 "hashtag meta-agent routing" (lines ~352-500)
-  - Remove describe section 4 "forum topic routing via topicNameCache" (lines ~502-659)
-  - Clean up `mocks.parseRoutingTagMock.mockReturnValue(null)` from all remaining beforeEach blocks
+## Files to Touch
+- `src/bot.ts` — all implementation changes
+- `src/loop-state.test.ts` — new test file
 
-**Keep untouched:**
-- `registerRoutedChatId` in BotOptions (still referenced in index.ts/notifier)
-- `metaAgentStatusKey` import and `/agents` command handler
-- `startNotifier` and notifier.ts
-- `src/index.ts`
-
----
-
-## Risks
-- Some tests in bot.error.test.ts reference topicNameCache directly via `(bot as any).topicNameCache`
-  — those tests are in the forum routing section being deleted, so fine.
-- META_AGENT_TIMEOUT_MS env var used only in ensureMetaAgent — becomes dead env var, no action needed.
+## Risks and Unknowns
+- Goal detection heuristic may produce false positives (conversational message classified as goal).
+  Mitigation: keep the heuristic conservative; short messages and explicit questions → question.
+- Completion gate may false-positive on response text that mentions "merged" in context without
+  actual completion. Mitigation: require specific compound patterns (PR URL, "npm publish" + version).
+- Re-prompting increases token spend. Mitigation: default max_iterations=3, user can /loop_stop.
+- `session.pendingText` may already have partial text from streaming chunks by the time `result`
+  fires. Looking at the code: result messages are the only ones that accumulate pendingText
+  (streaming assistant chunks are filtered out in handleClaudeMessage). Safe to intercept here.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,16 @@
-# TODO: feat/remove-hashtag-routing
+# TODO: feat/loop-state-tracking
 
-- [ ] Create branch feat/remove-hashtag-routing
-- [ ] Delete src/router.ts
-- [ ] Delete src/router.test.ts
-- [ ] Delete src/forum-routing.test.ts
-- [ ] Edit src/bot.ts: remove router import, topicNameCache, routing blocks, getForumRoutingConfig, normalizeTopicNamespace
-- [ ] Edit src/bot.error.test.ts: remove router mock, routing test sections, clean up beforeEach
-- [ ] Run build + tests
+- [ ] Create branch feat/loop-state-tracking
+- [ ] Add LoopState interface, update Session interface in src/bot.ts
+- [ ] Add classifyMessage() export function
+- [ ] Add checkCompletionGate() + formatLoopTrace() + buildLoopReprompt() helpers
+- [ ] Initialize loopState in handleTelegram message-send path
+- [ ] Intercept in handleClaudeMessage for loop gate logic
+- [ ] Add /loop_status and /loop_stop command handlers
+- [ ] Update BOT_COMMANDS array
+- [ ] Clear loopState on /start and /reset (already handled by killSession)
+- [ ] Write src/loop-state.test.ts with tests for all new logic
+- [ ] npm run build (verify dist/ compiles)
+- [ ] npm test (all tests pass)
 - [ ] git diff --staged review
 - [ ] Commit, push, PR, merge, publish

--- a/src/bot.integration.test.ts
+++ b/src/bot.integration.test.ts
@@ -186,7 +186,7 @@ describe('CcTgBot integration — message pipeline', () => {
   // 3. Long response split into multiple sendMessage calls
   // -------------------------------------------------------------------------
   it('response longer than 4096 chars is split into multiple messages', async () => {
-    await (bot as any).handleTelegram(makeMsg({ text: 'Write a lot' }));
+    await (bot as any).handleTelegram(makeMsg({ text: 'What is a long message?' }));
     // Generate text > 4096 chars, with word boundaries so it splits cleanly
     const longText = ('word '.repeat(900)).trim(); // ~4500 chars
     emitResult(longText);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -41,6 +41,8 @@ const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "wiki", description: "Manage wiki pages — list/show/update/delete/sync" },
   { command: "effort", description: "Set effort level: low / medium / high / xhigh / max / auto" },
   { command: "compact", description: "Compact context history to free tokens" },
+  { command: "loop_status", description: "Show current loop state if a loop is active" },
+  { command: "loop_stop", description: "Immediately flush and stop the active loop" },
 ];
 
 export interface BotOptions {
@@ -54,6 +56,17 @@ export interface BotOptions {
   /** Called when a message is routed to a non-default namespace so the notifier
    *  can forward the response back to the originating Telegram chat. */
   registerRoutedChatId?: (namespace: string, chatId: number) => void;
+}
+
+export interface LoopState {
+  goal: string;
+  iteration: number;
+  max_iterations: number;
+  gate_failures: Array<{
+    gate: string;
+    reason: string;
+    iteration: number;
+  }>;
 }
 
 interface Session {
@@ -74,6 +87,8 @@ interface Session {
   messagesSinceCompact: number;
   /** True once the CC_TG_COST_WARN_USD threshold notification has been sent */
   costWarnSent: boolean;
+  /** Active loop state — present only during goal-oriented loop iterations */
+  loopState?: LoopState;
 }
 
 interface PendingRetry {
@@ -139,6 +154,68 @@ function formatCostReport(cost: SessionCost): string {
     `  Output: ${formatTokens(cost.totalOutputTokens)} tokens ($${outputCost.toFixed(3)})`,
     `  Cache read: ${formatTokens(cost.totalCacheReadTokens)} tokens ($${cacheReadCost.toFixed(3)})`,
     `  Cache write: ${formatTokens(cost.totalCacheWriteTokens)} tokens ($${cacheWriteCost.toFixed(3)})`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Loop state helpers
+// ---------------------------------------------------------------------------
+
+const GOAL_IMPERATIVE_RE = /^(implement|add|fix|create|build|update|deploy|publish|remove|delete|refactor|write|generate|make|run|execute|migrate|move|rename|bump|release|merge|push|commit|revert|apply|enable|disable|install|uninstall|configure|setup|set up|extend|expose|wire|connect|register|convert)\b/i;
+const GOAL_INTENT_RE = /\b(loop|verify|iterate|ensure|automate)\b/i;
+const GOAL_FILE_RE = /\.(ts|js|tsx|jsx|py|go|rs|md|json|yaml|yml|toml|sh|css|html)\b/;
+const GOAL_VCS_RE = /\b(pr|pull request|commit|branch|merge|npm publish|git push|git tag|changelog)\b/i;
+const QUESTION_PREFIX_RE = /^(what|how|why|when|where|who|which|can|could|is|are|do|does|did|will|would|should|tell me|explain|describe|show me|help me understand)\b/i;
+
+/** Classify a user message as a goal (produces artifact) or question (conversational). */
+export function classifyMessage(text: string): "goal" | "question" {
+  const trimmed = text.trim();
+  if (trimmed.length < 10) return "question";
+  if (trimmed.endsWith("?")) return "question";
+  if (QUESTION_PREFIX_RE.test(trimmed)) return "question";
+  if (trimmed.startsWith("/")) return "question";
+  if (GOAL_INTENT_RE.test(trimmed)) return "goal";
+  if (GOAL_IMPERATIVE_RE.test(trimmed)) return "goal";
+  if (GOAL_FILE_RE.test(trimmed)) return "goal";
+  if (GOAL_VCS_RE.test(trimmed)) return "goal";
+  return "question";
+}
+
+const COMPLETION_PATTERNS: Array<{ gate: string; re: RegExp }> = [
+  { gate: "pr_url", re: /https:\/\/github\.com\/[^\s]+\/pull\/\d+/ },
+  { gate: "npm_published", re: /\b(npm publish|successfully published|package published)\b.*?@[\d.]+/i },
+  { gate: "merge_confirmed", re: /\b(PR merged|pull request merged|squash merged|auto-merge|merged successfully)\b/i },
+  { gate: "released", re: /\b(released|tagged|git tag|pushed.*tag)\b.*?v?[\d]+\.[\d]+\.[\d]+/i },
+  { gate: "agent_score", re: /AGENT_SCORE:\s*[0-9]/ },
+];
+
+/** Scan response text for completion signals. */
+export function checkCompletionGate(responseText: string): { passed: boolean; gate: string; reason: string } {
+  for (const { gate, re } of COMPLETION_PATTERNS) {
+    if (re.test(responseText)) return { passed: true, gate, reason: "" };
+  }
+  return {
+    passed: false,
+    gate: "completion_signal",
+    reason: "No PR URL, npm publish confirmation, merge confirmation, release tag, or AGENT_SCORE found in response",
+  };
+}
+
+function formatLoopTrace(loopState: LoopState): string {
+  if (loopState.gate_failures.length === 0) return "";
+  const lines = ["Gate failure trace:"];
+  for (const f of loopState.gate_failures) {
+    lines.push(`  iteration ${f.iteration}: [${f.gate}] ${f.reason}`);
+  }
+  return lines.join("\n");
+}
+
+function buildLoopReprompt(loopState: LoopState, gate: { gate: string; reason: string }): string {
+  return [
+    `[loop-iteration-${loopState.iteration}/${loopState.max_iterations}]`,
+    `Goal: ${loopState.goal}`,
+    `Previous response did not satisfy the completion gate (${gate.gate}): ${gate.reason}`,
+    "Please continue working toward the goal. When complete, ensure the response includes one of: a GitHub PR URL, npm publish confirmation, merge confirmation, a release tag, or AGENT_SCORE line.",
   ].join("\n");
 }
 
@@ -542,11 +619,32 @@ export class CcTgBot {
       return;
     }
 
+    // /loop_status — show current loop state
+    if (text === "/loop_status") {
+      await this.handleLoopStatus(chatId, threadId);
+      return;
+    }
+
+    // /loop_stop — flush current response and clear loop state
+    if (text === "/loop_stop") {
+      await this.handleLoopStop(chatId, threadId);
+      return;
+    }
+
     const session = this.getOrCreateSession(chatId, threadId, threadName);
     try {
       const enriched = await enrichPromptWithUrls(text);
       const prompt = buildPromptWithReplyContext(enriched, msg);
       session.currentPrompt = prompt;
+      // Initialize loop state for goal-oriented messages
+      if (classifyMessage(text) === "goal") {
+        session.loopState = {
+          goal: text,
+          iteration: 0,
+          max_iterations: 3,
+          gate_failures: [],
+        };
+      }
       this.maybeSendAutoCompact(session, chatId, threadId);
       session.claude.sendPrompt(stampPrompt(prompt));
       this.startTyping(chatId, session);
@@ -976,6 +1074,43 @@ export class CcTgBot {
 
       this.pendingRetries.set(retryKey, { text: lastPrompt, attempt, timer });
       return;
+    }
+
+    // Loop gate: when in loop mode, verify completion before flushing to user
+    if (session.loopState) {
+      const loopState = session.loopState;
+      const gate = checkCompletionGate(text);
+
+      if (!gate.passed) {
+        // Record this failure, then decide: re-prompt or exhaust
+        loopState.gate_failures.push({ gate: gate.gate, reason: gate.reason, iteration: loopState.iteration });
+        loopState.iteration++;
+
+        if (loopState.iteration >= loopState.max_iterations) {
+          // Exhausted — surface the response with exhaustion notice and full trace
+          const trace = formatLoopTrace(loopState);
+          const exhaustionSuffix = [
+            `\n\n[loop exhausted after ${loopState.iteration} iteration${loopState.iteration !== 1 ? "s" : ""} — handing off]`,
+            trace ? `\n\n${trace}` : "",
+          ].join("");
+          session.pendingText += text + exhaustionSuffix;
+          session.loopState = undefined;
+          if (session.flushTimer) clearTimeout(session.flushTimer);
+          session.flushTimer = setTimeout(() => this.flushPending(chatId, session), FLUSH_DELAY_MS);
+          console.log(`[loop:${chatId}] exhausted after ${loopState.max_iterations} iterations`);
+        } else {
+          // Gate failed — inject re-prompt without flushing to user
+          const reprompt = buildLoopReprompt(loopState, gate);
+          console.log(`[loop:${chatId}] gate failed (${gate.gate}), iteration=${loopState.iteration}/${loopState.max_iterations} — re-prompting`);
+          session.claude.sendPrompt(reprompt);
+          this.startTyping(chatId, session);
+        }
+        return;
+      }
+
+      // Completion gate passed — clear loop state and fall through to normal flush
+      console.log(`[loop:${chatId}] gate passed (${gate.gate}) after ${loopState.iteration} iteration${loopState.iteration !== 1 ? "s" : ""}`);
+      session.loopState = undefined;
     }
 
     // Accumulate text and debounce — Claude streams chunks rapidly
@@ -1894,6 +2029,53 @@ export class CcTgBot {
         `🗜️ Auto-compacting context (${threshold} message limit reached)...`,
         threadId
       ).catch(() => {});
+    }
+  }
+
+  private async handleLoopStatus(chatId: number, threadId?: number): Promise<void> {
+    const sessionKey = this.sessionKey(chatId, threadId);
+    const session = this.sessions.get(sessionKey);
+    if (!session || session.claude.exited) {
+      await this.replyToChat(chatId, "No active session.", threadId);
+      return;
+    }
+    const ls = session.loopState;
+    if (!ls) {
+      await this.replyToChat(chatId, "No active loop.", threadId);
+      return;
+    }
+    const lines = [
+      `Loop active — iteration ${ls.iteration}/${ls.max_iterations}`,
+      `Goal: ${ls.goal}`,
+    ];
+    if (ls.gate_failures.length > 0) {
+      lines.push("Gate failures:");
+      for (const f of ls.gate_failures) {
+        lines.push(`  [${f.gate}] iteration ${f.iteration}: ${f.reason}`);
+      }
+    }
+    await this.replyToChat(chatId, lines.join("\n"), threadId);
+  }
+
+  private async handleLoopStop(chatId: number, threadId?: number): Promise<void> {
+    const sessionKey = this.sessionKey(chatId, threadId);
+    const session = this.sessions.get(sessionKey);
+    if (!session || session.claude.exited) {
+      await this.replyToChat(chatId, "No active session.", threadId);
+      return;
+    }
+    const wasActive = !!session.loopState;
+    session.loopState = undefined;
+    if (wasActive) {
+      // Flush whatever we have buffered so far
+      if (session.flushTimer) {
+        clearTimeout(session.flushTimer);
+        session.flushTimer = null;
+        this.flushPending(chatId, session);
+      }
+      await this.replyToChat(chatId, "Loop stopped.", threadId);
+    } else {
+      await this.replyToChat(chatId, "No active loop.", threadId);
     }
   }
 

--- a/src/integration-bot.test.ts
+++ b/src/integration-bot.test.ts
@@ -210,7 +210,7 @@ describe('Bot → Claude → Telegram response pipeline', () => {
   // ── message splitting ──────────────────────────────────────────────────────
 
   it('splits long Claude responses into multiple Telegram messages', async () => {
-    await sendMsg(bot, { text: 'Write a lot' });
+    await sendMsg(bot, { text: 'What is a long message?' });
     // ~8000 chars with paragraph breaks — exceeds 4096 Telegram limit
     const longText = ('word '.repeat(60) + '\n\n').repeat(20).trim();
     emitClaudeResult(longText);

--- a/src/loop-state.test.ts
+++ b/src/loop-state.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for loop state tracking: classifyMessage, checkCompletionGate, and
+ * the loop flow wired into CcTgBot.handleClaudeMessage.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+// ---------------------------------------------------------------------------
+// Hoisted stubs
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  tgSendMessage: vi.fn().mockResolvedValue({ message_id: 1 }),
+  tgSendChatAction: vi.fn().mockResolvedValue({}),
+  tgSetMyCommands: vi.fn().mockResolvedValue({}),
+  tgStopPolling: vi.fn(),
+  tgGetMe: vi.fn().mockResolvedValue({ id: 999, username: "testbot" }),
+  claudeInstance: null as null | ClaudeStub,
+  existsSyncMock: vi.fn().mockReturnValue(false),
+  statSyncMock: vi.fn().mockReturnValue({ size: 1024, isFile: () => true }),
+  readFileSyncMock: vi.fn().mockReturnValue("{}"),
+  writeFileSyncMock: vi.fn(),
+  mkdirSyncMock: vi.fn(),
+  execSyncMock: vi.fn().mockReturnValue(""),
+}));
+
+class ClaudeStub extends EventEmitter {
+  sendPrompt = vi.fn();
+  sendImage = vi.fn();
+  kill = vi.fn();
+  exited = false;
+}
+
+vi.mock("node-telegram-bot-api", () => ({
+  default: vi.fn(function MockTelegramBot() {
+    return {
+      on: vi.fn(),
+      sendMessage: mocks.tgSendMessage,
+      sendChatAction: mocks.tgSendChatAction,
+      setMyCommands: mocks.tgSetMyCommands,
+      stopPolling: mocks.tgStopPolling,
+      getMe: mocks.tgGetMe,
+      sendDocument: vi.fn().mockResolvedValue({}),
+      getFileLink: vi.fn().mockResolvedValue("https://example.com/file"),
+    };
+  }),
+}));
+
+vi.mock("./claude.js", () => ({
+  ClaudeProcess: vi.fn(function MockClaudeProcess() {
+    const inst = new ClaudeStub();
+    mocks.claudeInstance = inst;
+    return inst;
+  }),
+  extractText: vi.fn(function extractText(msg: Record<string, unknown>) {
+    const payload = msg.payload as Record<string, unknown>;
+    if (msg.type === "result") return (payload?.result as string) ?? "";
+    return "";
+  }),
+}));
+
+vi.mock("./voice.js", () => ({
+  isVoiceAvailable: vi.fn().mockReturnValue(false),
+  transcribeVoice: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("./cron.js", () => ({
+  CronManager: vi.fn(function MockCronManager() {
+    return { list: vi.fn().mockReturnValue([]), add: vi.fn(), remove: vi.fn(), clearAll: vi.fn(), update: vi.fn() };
+  }),
+}));
+
+vi.mock("./notifier.js", () => ({
+  writeChatLog: vi.fn(),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: mocks.existsSyncMock,
+    statSync: mocks.statSyncMock,
+    readFileSync: mocks.readFileSyncMock,
+    writeFileSync: mocks.writeFileSyncMock,
+    mkdirSync: mocks.mkdirSyncMock,
+    readdirSync: vi.fn().mockReturnValue([]),
+    createWriteStream: vi.fn().mockReturnValue({ on: vi.fn(), end: vi.fn() }),
+  };
+});
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, execSync: mocks.execSyncMock, spawn: vi.fn() };
+});
+
+import { classifyMessage, checkCompletionGate, CcTgBot } from "./bot.js";
+
+// ---------------------------------------------------------------------------
+// classifyMessage
+// ---------------------------------------------------------------------------
+describe("classifyMessage", () => {
+  it("classifies imperative goal verbs as goal", () => {
+    expect(classifyMessage("implement it now")).toBe("goal");
+    expect(classifyMessage("Add loop state to sessions")).toBe("goal");
+    expect(classifyMessage("fix the bug in bot.ts")).toBe("goal");
+    expect(classifyMessage("deploy the release")).toBe("goal");
+    expect(classifyMessage("publish the npm package now")).toBe("goal");
+  });
+
+  it("classifies explicit loop/verify intent as goal", () => {
+    expect(classifyMessage("please iterate until it passes")).toBe("goal");
+    expect(classifyMessage("verify the PR was merged")).toBe("goal");
+  });
+
+  it("classifies file references as goal", () => {
+    expect(classifyMessage("update the config in settings.json")).toBe("goal");
+    expect(classifyMessage("review changes to src/bot.ts file")).toBe("goal");
+  });
+
+  it("classifies VCS references as goal", () => {
+    expect(classifyMessage("create a pull request for this change")).toBe("goal");
+    expect(classifyMessage("merge the branch and npm publish")).toBe("goal");
+  });
+
+  it("classifies question-word prefixes as question", () => {
+    expect(classifyMessage("what is the current version?")).toBe("question");
+    expect(classifyMessage("How does the loop state work?")).toBe("question");
+    expect(classifyMessage("why is the test failing")).toBe("question");
+    expect(classifyMessage("can you explain this?")).toBe("question");
+  });
+
+  it("classifies messages ending with ? as question", () => {
+    expect(classifyMessage("Please implement this feature?")).toBe("question");
+  });
+
+  it("classifies short messages as question", () => {
+    expect(classifyMessage("fix it")).toBe("question");
+    expect(classifyMessage("go")).toBe("question");
+  });
+
+  it("classifies slash-commands as question", () => {
+    expect(classifyMessage("/compact")).toBe("question");
+    expect(classifyMessage("/effort high")).toBe("question");
+  });
+
+  it("classifies ambiguous long non-imperative messages as question", () => {
+    expect(classifyMessage("the session seems to hang sometimes when the context is large")).toBe("question");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkCompletionGate
+// ---------------------------------------------------------------------------
+describe("checkCompletionGate", () => {
+  it("passes on GitHub PR URL", () => {
+    const result = checkCompletionGate(
+      "Done! PR created: https://github.com/Gonzih/cc-tg/pull/123"
+    );
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("pr_url");
+  });
+
+  it("passes on npm publish confirmation with version", () => {
+    const result = checkCompletionGate("npm publish successful @gonzih/cc-tg@0.9.63");
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("npm_published");
+  });
+
+  it("passes on merge confirmation", () => {
+    const result = checkCompletionGate("PR merged successfully into main.");
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("merge_confirmed");
+  });
+
+  it("passes on AGENT_SCORE line", () => {
+    const result = checkCompletionGate("Work complete.\n\nAGENT_SCORE: 1.0");
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("agent_score");
+  });
+
+  it("passes on release tag pattern", () => {
+    const result = checkCompletionGate("Tagged and released v1.2.3");
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("released");
+  });
+
+  it("fails when response contains no completion signal", () => {
+    const result = checkCompletionGate(
+      "I've started working on the implementation. Here is the plan:\n1. Add interface\n2. Wire up handlers"
+    );
+    expect(result.passed).toBe(false);
+    expect(result.gate).toBe("completion_signal");
+    expect(result.reason).toBeTruthy();
+  });
+
+  it("fails on partial progress with no artifact", () => {
+    const result = checkCompletionGate("Created branch feat/my-feature and pushed changes.");
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loop flow integration tests — CcTgBot
+// ---------------------------------------------------------------------------
+
+function makeMsg(overrides: Record<string, unknown> = {}) {
+  return { chat: { id: 42 }, from: { id: 100 }, text: "hello", ...overrides };
+}
+
+function emitResult(text: string) {
+  mocks.claudeInstance!.emit("message", { type: "result", payload: { result: text }, raw: {} });
+}
+
+describe("CcTgBot — loop state flow", () => {
+  let bot: CcTgBot;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.claudeInstance = null;
+    mocks.tgSendMessage.mockResolvedValue({ message_id: 1 });
+    mocks.readFileSyncMock.mockReturnValue("{}");
+    bot = new CcTgBot({ telegramToken: "tok" });
+  });
+
+  afterEach(() => {
+    bot.stop();
+    vi.useRealTimers();
+  });
+
+  it("does NOT initialize loopState for question-classified messages", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "what is the status?" }));
+    // Session is created but loopState must not be initialized for questions
+    const session = [...(bot as any).sessions.values()][0];
+    if (session) {
+      expect(session.loopState).toBeUndefined();
+    }
+    // Confirm classifyMessage correctly returns "question" for this input
+    expect(classifyMessage("what is the status?")).toBe("question");
+  });
+
+  it("initializes loopState for goal-classified messages", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the loop state tracking feature" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session).toBeDefined();
+    expect(session.loopState).toBeDefined();
+    expect(session.loopState.goal).toBe("implement the loop state tracking feature");
+    expect(session.loopState.iteration).toBe(0);
+    expect(session.loopState.max_iterations).toBe(3);
+    expect(session.loopState.gate_failures).toEqual([]);
+  });
+
+  it("flushes response to user when completion gate passes", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the feature in src/bot.ts" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session.loopState).toBeDefined();
+
+    // Emit a result with a PR URL (passes gate)
+    emitResult("Done! https://github.com/Gonzih/cc-tg/pull/42");
+
+    // flushTimer fires after FLUSH_DELAY_MS
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+
+    // loopState should be cleared
+    expect(session.loopState).toBeUndefined();
+    // Message should be flushed to user
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(
+      42,
+      expect.stringContaining("https://github.com/Gonzih/cc-tg/pull/42"),
+      expect.anything()
+    );
+  });
+
+  it("re-prompts Claude (no user flush) when gate fails and iterations remain", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the feature in src/bot.ts" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session.loopState).toBeDefined();
+
+    mocks.claudeInstance!.sendPrompt.mockClear();
+
+    // Emit a result with no completion signal
+    emitResult("I've started working on the feature. Here is the initial plan.");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+
+    // No message sent to Telegram
+    expect(mocks.tgSendMessage).not.toHaveBeenCalled();
+    // Claude was re-prompted
+    expect(mocks.claudeInstance!.sendPrompt).toHaveBeenCalledWith(
+      expect.stringContaining("[loop-iteration-1/3]")
+    );
+    // iteration incremented, gate_failures recorded
+    expect(session.loopState).toBeDefined();
+    expect(session.loopState!.iteration).toBe(1);
+    expect(session.loopState!.gate_failures).toHaveLength(1);
+    expect(session.loopState!.gate_failures[0].gate).toBe("completion_signal");
+  });
+
+  it("flushes with exhaustion trace when max_iterations reached", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the feature in src/bot.ts" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session.loopState).toBeDefined();
+
+    const noCompletionText = "Still working on it, no PR yet.";
+
+    // max_iterations=3 means 3 responses trigger exhaustion:
+    //   response 1: iteration 0→1 (re-prompt)
+    //   response 2: iteration 1→2 (re-prompt)
+    //   response 3: iteration 2→3, 3 >= 3 → exhaust
+    for (let i = 0; i < 3; i++) {
+      mocks.claudeInstance!.sendPrompt.mockClear();
+      emitResult(noCompletionText);
+      await vi.advanceTimersByTimeAsync(100);
+      await Promise.resolve();
+    }
+
+    // Advance enough for the flush debounce to fire on the exhaustion result
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+
+    expect(session.loopState).toBeUndefined();
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(
+      42,
+      expect.stringContaining("[loop exhausted after 3 iterations — handing off]"),
+      expect.anything()
+    );
+    // Should also include the failure trace
+    const flushedText = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(flushedText).toContain("Gate failure trace:");
+  });
+
+  it("does not enter loop mode for session-less reply (question short message)", async () => {
+    // Short message = question classification, no loopState
+    await (bot as any).handleTelegram(makeMsg({ text: "hello?" }));
+    // No sessions created (text is a question)
+    const sessions = [...(bot as any).sessions.values()];
+    // If session was somehow created, it should have no loopState
+    for (const s of sessions) {
+      expect(s.loopState).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /loop_status and /loop_stop commands
+// ---------------------------------------------------------------------------
+describe("CcTgBot — /loop_status and /loop_stop", () => {
+  let bot: CcTgBot;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.claudeInstance = null;
+    mocks.tgSendMessage.mockResolvedValue({ message_id: 1 });
+    mocks.readFileSyncMock.mockReturnValue("{}");
+    bot = new CcTgBot({ telegramToken: "tok" });
+  });
+
+  afterEach(() => {
+    bot.stop();
+    vi.useRealTimers();
+  });
+
+  it("/loop_status returns 'No active session.' when no session", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_status" }));
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, "No active session.");
+  });
+
+  it("/loop_stop returns 'No active session.' when no session", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_stop" }));
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, "No active session.");
+  });
+
+  it("/loop_status returns 'No active loop.' when session has no loop", async () => {
+    // Create session via a question message
+    await (bot as any).handleTelegram(makeMsg({ text: "what is the current status of the project?" }));
+    vi.clearAllMocks();
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_status" }));
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, "No active loop.");
+  });
+
+  it("/loop_stop returns 'No active loop.' when session has no loop", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "what is the current status of the project?" }));
+    vi.clearAllMocks();
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_stop" }));
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, "No active loop.");
+  });
+
+  it("/loop_status shows goal and iteration when loop is active", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the feature in src/bot.ts" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session.loopState).toBeDefined();
+
+    // Fail once to increment iteration
+    emitResult("Still working, no PR yet.");
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+
+    vi.clearAllMocks();
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_status" }));
+
+    const msg = mocks.tgSendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain("Loop active");
+    expect(msg).toContain("implement the feature in src/bot.ts");
+    expect(msg).toContain("1/3");
+  });
+
+  it("/loop_stop clears loopState and confirms", async () => {
+    await (bot as any).handleTelegram(makeMsg({ text: "implement the feature in src/bot.ts" }));
+    const session = [...(bot as any).sessions.values()][0];
+    expect(session.loopState).toBeDefined();
+
+    vi.clearAllMocks();
+    await (bot as any).handleTelegram(makeMsg({ text: "/loop_stop" }));
+
+    expect(session.loopState).toBeUndefined();
+    expect(mocks.tgSendMessage).toHaveBeenCalledWith(42, "Loop stopped.");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `LoopState` to the `Session` interface: `goal`, `iteration`, `max_iterations` (default 3), `gate_failures[]`
- `classifyMessage()` heuristic distinguishes goal-oriented messages (imperative verbs, file refs, VCS intent) from conversational questions — goals initialize `loopState`
- After each Claude result: `checkCompletionGate()` scans for PR URL, npm publish confirmation, merge confirmation, release tag, or `AGENT_SCORE` marker
- Gate pass → clear `loopState`, flush response to user (invisible on happy path)
- Gate fail with iterations remaining → record failure, increment iteration, inject structured re-prompt (no user message)
- Gate fail at `max_iterations` → flush response + exhaustion notice + full gate failure trace
- `/loop_status` command: shows active loop goal, iteration, and failure history
- `/loop_stop` command: immediately clears loop state and flushes any buffered response

## Test plan

- [x] `classifyMessage()` unit tests covering imperative verbs, question prefixes, file refs, VCS refs, short messages, slash-commands
- [x] `checkCompletionGate()` unit tests covering all 5 gate patterns + negative cases
- [x] Loop flow integration: goal message → loopState init
- [x] Loop flow integration: gate pass → flush to user, clear loopState
- [x] Loop flow integration: gate fail → re-prompt, no Telegram message, iteration++
- [x] Loop flow integration: exhaustion after max_iterations → trace flushed to user
- [x] `/loop_status` and `/loop_stop` command handlers
- [x] All 713 tests pass (28 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)